### PR TITLE
Resolve git & path sourced gems

### DIFF
--- a/lib/paperback/catalog/common.rb
+++ b/lib/paperback/catalog/common.rb
@@ -51,7 +51,7 @@ module Paperback::Catalog::Common
       @done_refresh[gem_name] = true
     end
 
-    gems_to_refresh
+    gems_to_refresh || []
   end
 
   def _info(name)

--- a/lib/paperback/direct_gem.rb
+++ b/lib/paperback/direct_gem.rb
@@ -2,7 +2,7 @@
 
 class Paperback::DirectGem < Paperback::StoreGem
   def load_gemspec(filename)
-    Paperback::GemspecParser.parse(File.read(filename), filename)
+    Paperback::GemspecParser.parse(File.read(filename), filename, isolate: false)
   end
 
   def initialize(root, name, version = nil)

--- a/lib/paperback/gemfile_parser.rb
+++ b/lib/paperback/gemfile_parser.rb
@@ -56,10 +56,7 @@ module Paperback::GemfileParser
     def gemspec
       if file = Dir["#{File.dirname(@result.filename)}/*.gemspec"].first
         spec = Paperback::GemspecParser.parse(File.read(file), file)
-        gem spec.name, spec.version, path: "."
-        spec.runtime_dependencies.each do |name, constraints|
-          gem name, constraints
-        end
+        gem spec.name, path: "."
         spec.development_dependencies.each do |name, constraints|
           gem name, constraints, group: :development
         end

--- a/lib/paperback/gemspec_parser.rb
+++ b/lib/paperback/gemspec_parser.rb
@@ -49,9 +49,41 @@ class Paperback::GemspecParser
     alias add_dependency add_runtime_dependency
   end
 
-  def self.parse(content, filename, lineno = 1, root: File.dirname(filename))
-    Dir.chdir(root) do
-      Context.context.eval(content, filename, lineno)
+  def self.parse(content, filename, lineno = 1, root: File.dirname(filename), isolate: true)
+    if isolate
+      in_read, in_write = IO.pipe
+      out_read, out_write = IO.pipe
+
+      pid = spawn(RbConfig.ruby, "--disable=gems",
+                  "-I", File.expand_path("..", __dir__),
+                  "-r", "paperback",
+                  "-r", "paperback/gemspec_parser",
+                  "-e", "puts Marshal.dump(Paperback::GemspecParser.parse($stdin.read, ARGV.shift, ARGV.shift.to_i, root: ARGV.shift, isolate: false))",
+                  filename, lineno.to_s, root,
+                  in: in_read, out: out_write)
+
+      in_read.close
+      out_write.close
+
+      write_thread = Thread.new do
+        in_write.write content
+        in_write.close
+      end
+
+      read_thread = Thread.new do
+        out_read.read
+      end
+
+      _, status = Process.waitpid2(pid)
+      raise "Gemspec parse failed" unless status.success?
+
+      write_thread.join
+      Marshal.load read_thread.value
+
+    else
+      Dir.chdir(root) do
+        Context.context.eval(content, filename, lineno)
+      end
     end
   end
 end

--- a/lib/paperback/git_catalog.rb
+++ b/lib/paperback/git_catalog.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require_relative "path_catalog"
+
+class Paperback::GitCatalog
+  attr_reader :git_depot, :remote, :ref
+
+  def initialize(git_depot, remote, ref)
+    @git_depot = git_depot
+    @remote = remote
+    @ref = ref
+  end
+
+  def checkout_result
+    @result ||= git_depot.resolve_and_checkout(remote, ref)
+  end
+
+  def revision
+    checkout_result[0]
+  end
+
+  def gem_info(name)
+    path_catalog.gem_info(name)
+  end
+
+  def path_catalog
+    @path_catalog ||= Paperback::PathCatalog.new(checkout_result[1])
+  end
+end

--- a/lib/paperback/git_depot.rb
+++ b/lib/paperback/git_depot.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+class Paperback::GitDepot
+  attr_reader :mirror_root
+
+  def initialize(store, mirror_root = "~/.cache/paperback/git")
+    @store = store
+    @mirror_root = File.expand_path(mirror_root)
+  end
+
+  def git_path(remote, revision)
+    short = File.basename(remote, ".git")
+    File.join(@store.root, "git", "#{short}-#{revision[0..12]}")
+  end
+
+  # Returns a path containing a local mirror of the given remote.
+  #
+  # If the mirror already exists, yields the path (same as the return
+  # value); if the block returns false the mirror will be updated.
+  def remote(remote)
+    cache_dir = "#{@mirror_root}/#{ident(remote)}"
+
+    if Dir.exist?(cache_dir)
+      if block_given? && !yield(cache_dir)
+        # The block didn't like what it saw; try updating the mirror
+        # from upstream
+        status = git("remote", "update", chdir: cache_dir)
+        raise "git remote update failed" unless status.success?
+      end
+    else
+      status = git("clone", "--mirror", remote, cache_dir)
+      raise "git clone --mirror failed" unless status.success?
+    end
+
+    cache_dir
+  end
+
+  def resolve(remote, ref)
+    mirror = remote(remote) { false } # always update mirror
+
+    r, w = IO.pipe
+    status = git("rev-parse", ref || "HEAD", chdir: mirror, out: w)
+    raise "git rev-parse failed" unless status.success?
+
+    w.close
+
+    r.read.chomp
+  end
+
+  def resolve_and_checkout(remote, ref)
+    revision = resolve(remote, ref)
+    [revision, checkout(remote, revision)]
+  end
+
+  def checkout(remote, revision)
+    destination = git_path(remote, revision)
+    return destination if Dir.exist?(destination)
+
+    mirror = remote(remote) do |cache_dir|
+      # Check whether the revision is already in our mirror
+      status = git("rev-list", "--quiet", revision, chdir: cache_dir)
+      status.success?
+    end
+
+    status = git("clone", mirror, destination)
+    raise "git clone --local failed" unless status.success?
+
+    status = git("checkout", "--detach", "--force", revision, chdir: destination)
+    raise "git checkout failed" unless status.success?
+
+    destination
+  end
+
+  private
+
+  def git(*arguments, **kwargs)
+    kwargs[:in] ||= IO::NULL
+    kwargs[:out] ||= IO::NULL
+    kwargs[:err] ||= IO::NULL
+
+    pid = spawn("git", *arguments, **kwargs)
+
+    _, status = Process.waitpid2(pid)
+
+    status
+  end
+
+  def ident(remote)
+    short = File.basename(remote, ".git")
+    digest = Digest(:SHA256).hexdigest(remote)[0..12]
+    "#{short}-#{digest}"
+  end
+end

--- a/lib/paperback/installer.rb
+++ b/lib/paperback/installer.rb
@@ -3,6 +3,7 @@
 require "monitor"
 
 require_relative "work_pool"
+require_relative "git_depot"
 require_relative "package"
 require_relative "package/installer"
 
@@ -31,6 +32,8 @@ class Paperback::Installer
 
     @download_pool.queue_order = -> ((_, name)) { -@weights[name] }
     @compile_pool.queue_order = -> ((_, name)) { -@weights[name] }
+
+    @git_depot = Paperback::GitDepot.new(store)
 
     @compile_waiting = []
   end
@@ -67,51 +70,17 @@ class Paperback::Installer
     end
   end
 
-  def load_git_gem(remote, revision, name, destination)
+  def load_git_gem(remote, revision, name)
     synchronize do
       @pending[name] += 1
       @download_pool.queue(name) do
-        work_git(remote, revision, name, destination)
+        work_git(remote, revision, name)
       end
     end
   end
 
-  def work_git(remote, revision, name, destination)
-    short = File.basename(remote, ".git")
-    digest = Digest(:SHA256).hexdigest(remote)[0..12]
-    cache_dir = File.expand_path("~/.cache/paperback/git/#{short}-#{digest}")
-    if Dir.exist?(cache_dir)
-      # Check whether the revision is already in our mirror
-      pid = spawn("git", "rev-list", "--quiet", revision,
-                  chdir: cache_dir,
-                  in: IO::NULL, [:out, :err] => IO::NULL)
-      _, status = Process.waitpid2(pid)
-
-      unless status.success?
-        # If not, try updating the mirror from upstream
-        pid = spawn("git", "remote", "update",
-                    chdir: cache_dir,
-                    in: IO::NULL, [:out, :err] => IO::NULL)
-        _, status = Process.waitpid2(pid)
-        raise "git remote update failed" unless status.success?
-      end
-    else
-      pid = spawn("git", "clone", "--mirror", remote, cache_dir,
-                  in: IO::NULL, [:out, :err] => IO::NULL)
-      _, status = Process.waitpid2(pid)
-      raise "git clone --mirror failed" unless status.success?
-    end
-
-    pid = spawn("git", "clone", cache_dir, destination,
-                in: IO::NULL, [:out, :err] => IO::NULL)
-    _, status = Process.waitpid2(pid)
-    raise "git clone --local failed" unless status.success?
-
-    pid = spawn("git", "checkout", "--detach", "--force", revision,
-                chdir: destination,
-                in: IO::NULL, [:out, :err] => IO::NULL)
-    _, status = Process.waitpid2(pid)
-    raise "git checkout failed" unless status.success?
+  def work_git(remote, revision, name)
+    @git_depot.checkout(remote, revision)
 
     @messages << "Using #{name} (git)\n"
     @pending[name] -= 1

--- a/lib/paperback/lock_loader.rb
+++ b/lib/paperback/lock_loader.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative "git_depot"
+
 class Paperback::LockLoader
   attr_reader :filename
   attr_reader :gemfile
@@ -94,6 +96,8 @@ class Paperback::LockLoader
 
     top_gems.each(&walk)
 
+    git_depot = Paperback::GitDepot.new(base_store)
+
     gems.each do |name, (section, body, version, platform, _deps)|
       next unless filtered_gems[name]
 
@@ -110,9 +114,9 @@ class Paperback::LockLoader
           remote = body["remote"].first
           revision = body["revision"].first
 
-          dir = env.git_path(remote, revision)
+          dir = git_depot.git_path(remote, revision)
           if installer && !Dir.exist?(dir)
-            installer.load_git_gem(remote, revision, name, dir)
+            installer.load_git_gem(remote, revision, name)
 
             locks[name] = -> { Paperback::DirectGem.new(dir, name, version) }
             next

--- a/lib/paperback/path_catalog.rb
+++ b/lib/paperback/path_catalog.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require_relative "gemspec_parser"
+
+class Paperback::PathCatalog
+  attr_reader :path
+
+  def initialize(path)
+    @path = path
+    @cache = {}
+  end
+
+  def gem_info(name)
+    @cache.fetch(name) { @cache[name] = _info(name) }
+  end
+
+  def _info(name)
+    gemspec = gemspec_from("#{name}.gemspec") ||
+      gemspec_from("#{name}/#{name}.gemspec")
+    return unless gemspec
+
+    info = {}
+    info[gemspec.version] = {
+      dependencies: gemspec.runtime_dependencies,
+      ruby: gemspec.required_ruby_version,
+    }
+
+    info
+  end
+
+  def gemspec_from(filename)
+    filename = File.expand_path("#{path}/#{filename}")
+    if File.exist?(filename)
+      Paperback::GemspecParser.parse(File.read(filename), filename)
+    end
+  end
+end

--- a/test/gemspec_parser_test.rb
+++ b/test/gemspec_parser_test.rb
@@ -39,7 +39,7 @@ end
 GEMSPEC
 
   def test_simple_parse
-    gemspec = Paperback::GemspecParser.parse(EXAMPLE, __FILE__, EXAMPLE_LINE, root: File.expand_path("..", __dir__))
+    gemspec = Paperback::GemspecParser.parse(EXAMPLE, __FILE__, EXAMPLE_LINE, root: File.expand_path("..", __dir__), isolate: false)
 
     assert_equal "paperback", gemspec.name
     assert_equal Paperback::VERSION, gemspec.version


### PR DESCRIPTION
@jhawthorn I had a go at this instead of writing tests for the existing behaviour, which is what I was supposed to be doing :sweat_smile:

I'll rebase it onto #2 later. They seem to be fairly orthogonal, so that's nice: the only changes to the SpecificationProvider are tracking which catalog each Spec came from, and an extra-dumb temp hack of a `nil` in the catalog list to avoid searching server catalogs for gems we definitely want to pull from the local source. 

I've been testing with paperback's own Gemfile, and a random Rails test app that points at my local clone, and uses git for some dependencies. Both are now coming out correctly.

Apart from the obvious lack of tests and desperate need for refactoring, the biggest actual limitations at the moment:
* gemspec for git sources isn't cached, so we fork for each one even when we know we've seen it before
* (unlike the install-from-lockfile workflow) these git operations run on the main thread -- we can't do any actual resolving before they're done, but they should run in parallel [with each other, and with the main catalog fetch]