### PR TITLE
Use GitHub API to check mirror freshness when available

### DIFF
--- a/lib/paperback/environment.rb
+++ b/lib/paperback/environment.rb
@@ -80,7 +80,7 @@ class Paperback::Environment
       "Gemfile.lock"
   end
 
-  def self.lock(output: nil, gemfile: Paperback::Environment.load_gemfile, lockfile: Paperback::Environment.lockfile_name, catalog_options: {})
+  def self.lock(output: nil, gemfile: Paperback::Environment.load_gemfile, lockfile: Paperback::Environment.lockfile_name, catalog_options: {}, git_options: {})
     if lockfile && File.exist?(lockfile)
       loader = Paperback::LockLoader.new(lockfile, gemfile)
       # TODO
@@ -110,7 +110,7 @@ class Paperback::Environment
     path_sources = gemfile.gems.map { |_, _, o| o[:path] }.compact
 
     require_relative "git_depot"
-    git_depot = Paperback::GitDepot.new(Paperback::Environment.store)
+    git_depot = Paperback::GitDepot.new(Paperback::Environment.store, **git_options)
 
     require_relative "path_catalog"
     require_relative "git_catalog"

--- a/test/resolve_test.rb
+++ b/test/resolve_test.rb
@@ -636,6 +636,7 @@ LOCKFILE
           gemfile: Paperback::GemfileParser.parse(gemfile),
           lockfile: nil,
           catalog_options: { cache: cache_dir },
+          git_options: { cache: cache_dir },
         )
 
         assert_match(/\AFetching sources\.\.\.+\nResolving dependencies\.\.\.+\n\z/, output.string)


### PR DESCRIPTION
If people have git references to a number of public GitHub repositories, this turns some multi-round-trip git communications into single HTTP requests.

If the repository isn't public, this wastes an HTTP request because we still need to continue and do the mirror update -- but it remembers the failure and doesn't try again, so it's only a one-off cost.