### PR TITLE
Give `lock` control over which packages get updated

### DIFF
--- a/lib/paperback/command/lock.rb
+++ b/lib/paperback/command/lock.rb
@@ -4,8 +4,29 @@ class Paperback::Command::Lock < Paperback::Command
   def run(command_line)
     options = {}
 
-    if command_line.first =~ /\A--lockfile=(.*)/
-      options[:lockfile] = $1
+    mode = :hold
+    strict = false
+    overrides = {}
+
+    until command_line.empty?
+      case argument = command_line.shift
+      when "--strict"; strict = true
+      when "--major"; mode = :major
+      when "--minor"; mode = :minor
+      when "--patch"; mode = :patch
+      when "--hold"; mode = :hold
+      when /\A--lockfile(?:=(.*))?\z/
+        options[:lockfile] = $1 || command_line.shift
+      when /\A((?!-)[A-Za-z0-9_-]+)(?:(?:[\ :\/]|(?=[<>~=]))([<>~=,\ 0-9A-Za-z.-]+))?\z/x
+        overrides[$1] = Paperback::Support::GemRequirement.new($2 ? $2.split(/\s+(?=[0-9])|\s*,\s*/) : [])
+      else
+        raise "Unknown argument #{argument.inspect}"
+      end
+    end
+
+    require_relative "../pub_grub/preference_strategy"
+    options[:preference_strategy] = lambda do |loader|
+      Paperback::PubGrub::PreferenceStrategy.new(loader, overrides, bump: mode, strict: strict)
     end
 
     Paperback::Environment.lock(output: $stderr, **options)

--- a/lib/paperback/pub_grub/preference_strategy.rb
+++ b/lib/paperback/pub_grub/preference_strategy.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+module Paperback::PubGrub
+  class PreferenceStrategy
+    def initialize(loader, overrides, bump: :major, strict: false)
+      @loader = loader
+      @overrides = overrides
+      @bump = bump
+      @strict = strict
+    end
+
+    # Overrides first, then packages for which we have a preference (and
+    # that preference is still in play), then everything else.
+    def package_priority(package, versions)
+      if package.name =~ /^~/
+        -1000
+      elsif @overrides.key?(package.name)
+        -100
+      elsif range = ranges[package.name]
+        yes, no = versions.partition { |version| range.satisfied_by?(version) }
+        if yes.any? && no.any?
+          -50
+        else
+          0
+        end
+      else
+        0
+      end
+    end
+
+    def sort_versions_by_preferred(package, versions)
+      return versions if @strict # already filtered
+      return versions unless range = ranges[package.name]
+      versions.partition { |version| range.satisfied_by?(version) }.inject(:+)
+    end
+
+    def constraints
+      ranges = @strict ? self.ranges : @overrides
+
+      result = {}
+      ranges.each do |package_name, range|
+        result[package_name] = [range] if range
+      end
+      result
+    end
+
+    private
+
+    def ranges
+      @ranges ||=
+        begin
+          result = @overrides.dup
+          @loader.each_gem do |section, body, name, version, platform, deps|
+            next if @overrides.key?(name)
+
+            result[name] = range_for(version, @bump)
+          end
+          result.delete_if { |_, v| !v }
+          result
+        end
+    end
+
+    def range_for(version, bump)
+      version = Paperback::Support::GemVersion.new(version)
+
+      case bump
+      when :major
+        Paperback::Support::GemRequirement.new ">= #{version}"
+      when :minor
+        next_major = version.bump
+        next_major = next_major.bump while next_major.segments.size > 2
+        Paperback::Support::GemRequirement.new [">= #{version}", "< #{next_major}"]
+      when :patch
+        next_minor = version.bump
+        next_minor = next_minor.bump while next_minor.segments.size > 3
+        Paperback::Support::GemRequirement.new [">= #{version}", "< #{next_minor}"]
+      when :hold
+        Paperback::Support::GemRequirement.new "= #{version}"
+      end
+    end
+  end
+end


### PR DESCRIPTION
We now respect the existing entries in the lockfile, and only update
when we're told to update everything by a certain level (--major etc),
or a specific packages is listed on the command line (or where necessary
to satisfy other packages).

Note these rules are conceptually similar to Bundler's, but [currently?]
intentionally different in detail.