### PR TITLE
Platform filtering

### DIFF
--- a/lib/paperback/lock_loader.rb
+++ b/lib/paperback/lock_loader.rb
@@ -47,6 +47,12 @@ class Paperback::LockLoader
     end
   end
 
+  def platforms
+    if pair = lock_content.assoc("PLATFORMS")
+      pair.last
+    end
+  end
+
   def activate(env, base_store, install: false, output: nil)
     locked_store = Paperback::LockedStore.new(base_store)
 

--- a/lib/paperback/platform.rb
+++ b/lib/paperback/platform.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Paperback::Platform
+  SYNONYMS = [
+    ["ruby", "mri"],
+    ["java", "jruby"],
+    ["x64-mingw32", "mswin64", "x64_mingw"],
+    ["x86-mingw32", "mswin", "mingw"],
+  ]
+
+  def self.filter(target_platforms, filter)
+    # Ignore ruby-version constraint tails ("mri_23" => "mri")
+    filter = filter.map { |f| f.sub(/_[0-9]+\z/, "") }
+
+    target_platforms.select do |platform|
+      next true if filter.include?(platform)
+
+      SYNONYMS.any? do |row|
+        row.include?(platform) && !(row & filter).empty?
+      end
+    end
+  end
+
+  def self.match(target_platform, available_platforms)
+    return target_platform if available_platforms.include?(target_platform)
+
+    SYNONYMS.each do |row|
+      next unless row.include?(target_platform)
+
+      overlap = row & available_platforms
+      return overlap.first unless overlap.empty?
+    end
+
+    return "ruby" if available_platforms.include?("ruby")
+
+    nil
+  end
+end


### PR DESCRIPTION
This is my attempt to solve the issues I identified in #11.

It feels like a not-great solution (and is a truly terrible string-munging implementation of said solution), but it _is_ working. On my (by now slightly out of date) rails/rails master:

```diff
diff --git a/Gemfile.lock b/Gemfile.lock
index 7b30653745..9fc9d68906 100644
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,9 +17,9 @@ GIT

 GIT
   remote: https://github.com/rails/webpacker.git
-  revision: bb132d591da35095e3246082cba3d693f847e0b5
+  revision: 48d52362ac77e34c94623ec9a194403abd55d984
   specs:
-    webpacker (4.0.0.pre.3)
+    webpacker (4.0.0.rc.3)
       activesupport (>= 4.2)
       rack-proxy (>= 0.6.1)
       railties (>= 4.2)
@@ -27,70 +27,70 @@ GIT
 PATH
   remote: .
   specs:
-    actioncable (6.0.0.alpha)
-      actionpack (= 6.0.0.alpha)
+    actioncable (5.2.999.alpha)
+      actionpack (= 5.2.999.alpha)
       nio4r (~> 2.0)
       websocket-driver (>= 0.6.1)
-    actionmailbox (6.0.0.alpha)
-      actionpack (= 6.0.0.alpha)
-      activejob (= 6.0.0.alpha)
-      activerecord (= 6.0.0.alpha)
-      activestorage (= 6.0.0.alpha)
-      activesupport (= 6.0.0.alpha)
+    actionmailbox (5.2.999.alpha)
+      actionpack (= 5.2.999.alpha)
+      activejob (= 5.2.999.alpha)
+      activerecord (= 5.2.999.alpha)
+      activestorage (= 5.2.999.alpha)
+      activesupport (= 5.2.999.alpha)
       mail (>= 2.7.1)
-    actionmailer (6.0.0.alpha)
-      actionpack (= 6.0.0.alpha)
-      actionview (= 6.0.0.alpha)
-      activejob (= 6.0.0.alpha)
+    actionmailer (5.2.999.alpha)
+      actionpack (= 5.2.999.alpha)
+      actionview (= 5.2.999.alpha)
+      activejob (= 5.2.999.alpha)
       mail (~> 2.5, >= 2.5.4)
       rails-dom-testing (~> 2.0)
-    actionpack (6.0.0.alpha)
-      actionview (= 6.0.0.alpha)
-      activesupport (= 6.0.0.alpha)
+    actionpack (5.2.999.alpha)
+      actionview (= 5.2.999.alpha)
+      activesupport (= 5.2.999.alpha)
       rack (~> 2.0)
       rack-test (>= 0.6.3)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.0.2)
-    actionview (6.0.0.alpha)
-      activesupport (= 6.0.0.alpha)
+    actionview (5.2.999.alpha)
+      activesupport (= 5.2.999.alpha)
       builder (~> 3.1)
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.0.3)
-    activejob (6.0.0.alpha)
-      activesupport (= 6.0.0.alpha)
+    activejob (5.2.999.alpha)
+      activesupport (= 5.2.999.alpha)
       globalid (>= 0.3.6)
-    activemodel (6.0.0.alpha)
-      activesupport (= 6.0.0.alpha)
-    activerecord (6.0.0.alpha)
-      activemodel (= 6.0.0.alpha)
-      activesupport (= 6.0.0.alpha)
-    activestorage (6.0.0.alpha)
-      actionpack (= 6.0.0.alpha)
-      activerecord (= 6.0.0.alpha)
+    activemodel (5.2.999.alpha)
+      activesupport (= 5.2.999.alpha)
+    activerecord (5.2.999.alpha)
+      activemodel (= 5.2.999.alpha)
+      activesupport (= 5.2.999.alpha)
+    activestorage (5.2.999.alpha)
+      actionpack (= 5.2.999.alpha)
+      activerecord (= 5.2.999.alpha)
       marcel (~> 0.3.1)
-    activesupport (6.0.0.alpha)
+    activesupport (5.2.999.alpha)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-    rails (6.0.0.alpha)
-      actioncable (= 6.0.0.alpha)
-      actionmailbox (= 6.0.0.alpha)
-      actionmailer (= 6.0.0.alpha)
-      actionpack (= 6.0.0.alpha)
-      actionview (= 6.0.0.alpha)
-      activejob (= 6.0.0.alpha)
-      activemodel (= 6.0.0.alpha)
-      activerecord (= 6.0.0.alpha)
-      activestorage (= 6.0.0.alpha)
-      activesupport (= 6.0.0.alpha)
+    rails (5.2.999.alpha)
+      actioncable (= 5.2.999.alpha)
+      actionmailbox (= 5.2.999.alpha)
+      actionmailer (= 5.2.999.alpha)
+      actionpack (= 5.2.999.alpha)
+      actionview (= 5.2.999.alpha)
+      activejob (= 5.2.999.alpha)
+      activemodel (= 5.2.999.alpha)
+      activerecord (= 5.2.999.alpha)
+      activestorage (= 5.2.999.alpha)
+      activesupport (= 5.2.999.alpha)
       bundler (>= 1.3.0)
-      railties (= 6.0.0.alpha)
+      railties (= 5.2.999.alpha)
       sprockets-rails (>= 2.0.0)
-    railties (6.0.0.alpha)
-      actionpack (= 6.0.0.alpha)
-      activesupport (= 6.0.0.alpha)
+    railties (5.2.999.alpha)
+      actionpack (= 5.2.999.alpha)
+      activesupport (= 5.2.999.alpha)
       method_source
       rake (>= 0.8.7)
       thor (>= 0.20.3, < 2.0)
@@ -356,7 +356,6 @@ GEM
     pg (1.1.3-x64-mingw32)
     pg (1.1.3-x86-mingw32)
     powerpack (0.1.2)
-    psych (3.0.3)
     public_suffix (3.0.3)
     puma (3.12.0)
     puma (3.12.0-java)
@@ -553,7 +552,6 @@ DEPENDENCIES
   mysql2 (>= 0.4.10)
   nokogiri (>= 1.8.1)
   pg (>= 0.18.0)
-  psych (~> 3.0)
   puma
   que
   queue_classic!
@@ -587,4 +585,4 @@ DEPENDENCIES
   websocket-client-simple!

 BUNDLED WITH
-   1.17.2
+   1.999
diff --git a/RAILS_VERSION b/RAILS_VERSION
index 747766c587..5e941d828a 100644
--- a/RAILS_VERSION
+++ b/RAILS_VERSION
@@ -1 +1 @@
-6.0.0.alpha
+5.2.999.alpha
```

I've changed `RAILS_VERSION` to work around the other known issue, where Bundler seemingly ignores some version constraints directed at local gems -- I haven't fixed that yet because I can't find a definition of the right behaviour.

But other than that, and the resultant `s/6.0.0.alpha/5.2.999.alpha/g`, we can see we're getting all the per-platform stuff right (including e.g. `activerecord-jdbc-adapter`, which is a dependency [so no explicit platform limitation], and whose chosen version is only available for java). The only other discrepancies are the git sha on webpacker (because `lock` currently always updates git sources), and the removal of `psych`, because we don't recognise `rbx` as a platform.

(Ultimately, unknown platforms should raise, to catch typos etc. But I'm somewhat inclined to leave rbx blackholed even then... no need to complain that people have mentioned it, but I'm not excited to go out of our way to actually support it either.)