### PR TITLE
Split extra long strings over multiple SDBM values

### DIFF
--- a/lib/paperback/db.rb
+++ b/lib/paperback/db.rb
@@ -146,6 +146,9 @@ end
 
 class Paperback::DB::SDBM < Paperback::DB
   prepend Paperback::DB::AutoTransaction
+  SDBM_MAX_STORE_SIZE = 1000 - 1 # arbitrary on PBLKSIZ-N
+  SAFE_DELIMITER = '---'
+
 
   def initialize(root, name)
     @sdbm = ::SDBM.new("#{root}/#{name}")
@@ -167,14 +170,52 @@ class Paperback::DB::SDBM < Paperback::DB
     !!@sdbm[key.to_s]
   end
 
+  ##
+  # Retrieve the value from SDBM and handle for when we split
+  # over multiple stores. It is safe to assume that the value
+  # stored will be a marshaled value or a integer implying the
+  # amount of extra stores to retrieve the data string form. A
+  # marshaled store would have special starting delimiter that
+  # is not a decimal. If a number is not found at start of string
+  # then simply load it as a string and you get a value that
+  # is then marshaled.
   def [](key)
-    if value = @sdbm[key.to_s]
-      Marshal.load(value)
+    value = @sdbm[key.to_s]
+    return nil unless value
+
+    if value =~ /\A~(\d+)\z/
+      value = $1.to_i.times.map do |idx|
+        @sdbm["#{key}#{SAFE_DELIMITER}#{idx}"]
+      end.join
     end
+
+    return Marshal.load(value)
   end
 
+
+  ##
+  # SDBM has an arbitrary limit on the size of a string it stores,
+  # so we simply split any string over multiple stores for the edge
+  # case when it reaches this. It's optimised to take advantage of the common
+  # case where this is not needed.
+  # When the edge case is hit, the first value in the storage will be the amount
+  # of extra values stored to hold the split string. This amount is determined by string
+  # size split by the arbitrary limit imposed by SDBM
   def []=(key, value)
-    @sdbm[key.to_s] = value && Marshal.dump(value)
+    return unless value && key
+
+    dump = Marshal.dump(value)
+    count = dump.length / SDBM_MAX_STORE_SIZE
+
+    if count > 0
+      count += 1
+      @sdbm["#{key.to_s}"] = "~#{count}"
+      count.times.map do |idx|
+        @sdbm["#{key.to_s}#{SAFE_DELIMITER}#{idx}"] = dump.slice!(0, SDBM_MAX_STORE_SIZE)
+      end
+    else
+      @sdbm[key.to_s] = dump
+    end
   end
 end
 

--- a/test/db_test.rb
+++ b/test/db_test.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class DbTest < Minitest::Test
+  def test_sdbm_store_value_retrieval
+    skip unless defined? ::SDBM
+    Dir.mktmpdir do |dir|
+      db = Paperback::DB::SDBM.new(dir, 'test-store')
+
+      # Still handles ints okay
+      db['test'] = 12
+      assert_equal db['test'], 12
+
+      # A simple string should return a simple string
+      db['test'] = 'Hello World'
+      assert_equal db['test'], 'Hello World'
+
+      # A simple hash should return a simple hash
+      db['test'] = { a: 'Hello World' }
+      assert_equal db['test'], { a: 'Hello World' }
+
+      # A string that will be split up over multiple stores
+      long_string = '*' * (Paperback::DB::SDBM::SDBM_MAX_STORE_SIZE + 200)
+      db['test'] = long_string
+      assert_equal db['test'], long_string
+
+      # A object with a long string gets stored and marshaled correctly
+      hash_string = { a: long_string, b: long_string }
+      db['test'] = hash_string
+      assert_equal db['test'], hash_string
+    end
+  end
+end


### PR DESCRIPTION
SDBM has an arbitrary limit on string sizes stored. This was reached in the AWS gem suite when resolving gemspec dependencies. This commit changes it to split the string over multiple objects when the gemspec exceed this arbitrary limit.