### PR TITLE
Need to require shellwords

### DIFF
--- a/lib/gel/package/installer.rb
+++ b/lib/gel/package/installer.rb
@@ -4,6 +4,7 @@ require "fileutils"
 require "pathname"
 require "rbconfig"
 require "tempfile"
+require "shellwords"
 
 class Gel::Package::Installer
   def initialize(store)


### PR DESCRIPTION
Fix this error if you run the test with just `rake`:

```
  1) Error:
ActivateTest#test_activate_gem_with_extensions:
NameError: uninitialized constant Gel::Package::Installer::GemInstaller::Shellwords
```