### PR TITLE
REF: Moved mkrf_conf error to errors lib

### DIFF
--- a/lib/gel/error.rb
+++ b/lib/gel/error.rb
@@ -142,18 +142,18 @@ module Gel::Error
     end
   end
 
-  class MkrfConfError < Gel::UserError
-    def initialzie(exitstatus:)
+  class ExtensionBuildError < Gel::UserError
+    def initialize(program_name:, exitstatus:)
       super
     end
 
     def message
-      "mkrf_conf exited with #{self[:exitstatus].inspect}"
+      "#{self[:program_name].inspect} exited with #{self[:exitstatus].inspect}"
     end
   end
 
   class NoGemfile < Gel::UserError
-    def initialzie(path:)
+    def initialize(path:)
       super
     end
 

--- a/lib/gel/error.rb
+++ b/lib/gel/error.rb
@@ -142,6 +142,16 @@ module Gel::Error
     end
   end
 
+  class MkrfConfError < Gel::UserError
+    def initialzie(exitstatus:)
+      super
+    end
+
+    def message
+      "mkrf_conf exited with #{self[:exitstatus].inspect}"
+    end
+  end
+
   class NoGemfile < Gel::UserError
     def initialzie(path:)
       super

--- a/lib/gel/package/installer.rb
+++ b/lib/gel/package/installer.rb
@@ -183,7 +183,7 @@ class Gel::Package::Installer
             File.basename(ext),
             rake: true,
           )
-          raise Gel::Error::MkrfConfError.new(exitstatus: status.exitstatus) unless status.success?
+          raise Gel::Error::ExtensionBuildError.new(program_name: "mkrf_conf", exitstatus: status.exitstatus) unless status.success?
         end
 
         status = build_command(
@@ -197,7 +197,7 @@ class Gel::Package::Installer
           "rake",
           rake: true,
         )
-        raise Gel::Error::MkrfConfError.new(exitstatus: status.exitstatus) unless status.success?
+        raise Gel::Error::ExtensionBuildError.new(program_name: "rake", exitstatus: status.exitstatus) unless status.success?
       end
     end
 

--- a/lib/gel/package/installer.rb
+++ b/lib/gel/package/installer.rb
@@ -183,7 +183,7 @@ class Gel::Package::Installer
             File.basename(ext),
             rake: true,
           )
-          raise "mkrf_conf exited with #{status.exitstatus}" unless status.success?
+          raise Gel::Error::MkrfConfError.new(exitstatus: status.exitstatus) unless status.success?
         end
 
         status = build_command(
@@ -197,6 +197,7 @@ class Gel::Package::Installer
           "rake",
           rake: true,
         )
+        raise Gel::Error::MkrfConfError.new(exitstatus: status.exitstatus) unless status.success?
       end
     end
 

--- a/test/install_test.rb
+++ b/test/install_test.rb
@@ -6,6 +6,12 @@ require "gel/package"
 require "gel/package/installer"
 
 class InstallTest < Minitest::Test
+  def test_no_gemfile
+    Gel::Environment.gemfile = nil
+    exception = assert_raises(Exception) { Gel::Environment.find_gemfile("/blub") }
+    assert_equal( "No Gemfile found in \"/blub\"", exception.message )
+  end
+
   def test_install_single_package
     Dir.mktmpdir do |dir|
       store = Gel::Store.new(dir)


### PR DESCRIPTION
Hey 👋 

Since this project has a `.rubocop.yml` file, I guessed that doing some rubocop refactoring wouldn't be bad. Thats what I did here. Also extracted the `mkrf_conf` errors to the `lib/errors.rb`

Together with #29 all rubocop warnings / errors should be fixed now 🙂