### PR TITLE
Add basic gel help command

### DIFF
--- a/lib/gel/command/help.rb
+++ b/lib/gel/command/help.rb
@@ -1,7 +1,18 @@
 # frozen_string_literal: true
 
 class Gel::Command::Help < Gel::Command
-  def run(command_line)
-    raise "TODO"
+  def run(_command_line)
+    puts <<~HELP
+      Gel is a modern gem manager.
+
+      Usage:
+        gel help       Print this help message.
+        gel install    Install the gems from Gemfile.
+        gel lock       Update lockfile without installing.
+        gel exec       Run command in context of the gel.
+
+      Further information:
+        https://gel.dev/
+    HELP
   end
 end

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -20,6 +20,12 @@ class CLITest < Minitest::Test
     end
   end
 
+  def test_basic_help
+    Gel::Command::Help.expects(:new).returns(mock(run: true))
+
+    Gel::Command.run(%W(help))
+  end
+
   def test_basic_install
     Gel::Environment.expects(:activate).with(has_entries(install: true, output: $stderr))
 

--- a/test/command/help_test.rb
+++ b/test/command/help_test.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class HelpTest < Minitest::Test
+  def test_help
+    output = capture_stdout { Gel::Command::Help.run(["help"]) }
+
+    assert output =~ %r{Gel is a modern gem manager}
+    assert output =~ %r{Usage}
+    assert output =~ %r{https://gel.dev}
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -175,3 +175,12 @@ end
 def jruby?
   RUBY_ENGINE == "jruby"
 end
+
+def capture_stdout
+  original_stdout = $stdout
+  $stdout = StringIO.new
+  yield
+  $stdout.string
+ensure
+  $stdout = original_stdout
+end


### PR DESCRIPTION
This Pull Request implements part of #36.

I will add support for `-h` and `--help` in coming Pull Request if we want to.

```
$ gel help
Gel is a modern gem manager.

Usage:
  gel help       Print this help message.
  gel install    Install the gems from Gemfile.
  gel lock       Update lockfile without installing.
  gel exec       Run command in context of the gel.

Further information:
  https://gel.dev/
```

Currently prints a very basic help message.

- [x] I manually tested these changes
  ```
  bin/setup && bin/rake
  ```
