### PR TITLE
Introduce Fish shell support

### DIFF
--- a/lib/gel/command/shell_setup.rb
+++ b/lib/gel/command/shell_setup.rb
@@ -4,22 +4,25 @@ class Gel::Command::ShellSetup < Gel::Command
   def run(command_line)
     require "shellwords"
 
-    variables = []
+    shell = command_line[0] || File.basename(ENV["SHELL"])
 
     bin_dir = File.expand_path("~/.local/gel/bin")
     unless ENV.fetch("PATH", "").split(File::PATH_SEPARATOR).include?(bin_dir)
-      puts "PATH=\"#{Shellwords.shellescape bin_dir}#{File::PATH_SEPARATOR}$PATH\""
-      variables << "PATH"
+      puts export("PATH", "\"#{Shellwords.shellescape bin_dir}#{File::PATH_SEPARATOR}$PATH\"", shell: shell)
     end
 
     lib_dir = File.expand_path("../compatibility", __dir__)
     unless ENV.fetch("RUBYLIB", "").split(File::PATH_SEPARATOR).include?(lib_dir)
-      puts "RUBYLIB=\"#{Shellwords.shellescape lib_dir}:$RUBYLIB\""
-      variables << "RUBYLIB"
+      puts export("RUBYLIB", "\"#{Shellwords.shellescape lib_dir}:$RUBYLIB\"", shell: shell)
     end
+  end
 
-    unless variables.empty?
-      puts "export #{variables.join(" ")}"
+  def export(env, value, shell: nil)
+    case shell
+    when "fish"
+      "set -x #{env} #{value}"
+    else
+      "export #{env}=#{value}"
     end
   end
 end


### PR DESCRIPTION
I'm running on [Fish shell](https://fishshell.com) and the current shell setup doesn't work for me, without having to manually modify it. This introduces support for fish shell extension and possibly a small abstraction that can be reused if other shells that don't use the standard bash/zsh-like syntax need to be supported.