### PR TITLE
Don't pass Marshal data over STDOUT in GemspecParser

### DIFF
--- a/lib/gel/gemspec_parser.rb
+++ b/lib/gel/gemspec_parser.rb
@@ -64,9 +64,9 @@ class Gel::GemspecParser
                   RbConfig.ruby,
                   "-r", File.expand_path("compatibility", __dir__),
                   "-r", File.expand_path("gemspec_parser", __dir__),
-                  "-e", "puts Marshal.dump(Gel::GemspecParser.parse($stdin.read, ARGV.shift, ARGV.shift.to_i, root: ARGV.shift, isolate: false))",
+                  "-e", "IO.new(3, 'w').write Marshal.dump(Gel::GemspecParser.parse($stdin.read, ARGV.shift, ARGV.shift.to_i, root: ARGV.shift, isolate: false))",
                   filename, lineno.to_s, root,
-                  in: in_read, out: out_write)
+                  in: in_read, 3 => out_write)
 
       in_read.close
       out_write.close


### PR DESCRIPTION
I was doing some puts debugging, and that caused an error here because my puts was messing up the Marshal output.

I could have used `$stderr.puts` for my debugging, but I think we might as well use a non-standard (non-default?) fd to pass this data.