### PR TITLE
Add support for specify multiple Ruby versions

### DIFF
--- a/test/gemfile_parser_test.rb
+++ b/test/gemfile_parser_test.rb
@@ -102,4 +102,42 @@ GEMFILE
       assert_equal "", output.shift
     end
   end
+
+  def test_jruby_9000
+    Gel::GemfileParser::RunningRuby.expects(:version).returns("2.2.2")
+    Gel::GemfileParser::RunningRuby.expects(:engine).returns("jruby")
+    Gel::GemfileParser::RunningRuby.expects(:engine_version).returns("9.0.0.0")
+
+    result = Gel::GemfileParser.parse(<<GEMFILE, __FILE__, __LINE__ + 1)
+source "https://rubygems.org"
+
+ruby "2.2.2", engine: "jruby", engine_version: "9.0.0.0"
+GEMFILE
+
+    assert_equal [["2.2.2"], {:engine=>"jruby", :engine_version=>"9.0.0.0"}], result.ruby.first
+  end
+
+  def test_ruby_version_specifier
+    Gel::GemfileParser::RunningRuby.expects(:version).returns("2.6.3")
+
+    result = Gel::GemfileParser.parse(<<GEMFILE, __FILE__, __LINE__ + 1)
+source "https://rubygems.org"
+
+ruby "~> 2.6.0"
+GEMFILE
+
+    assert_equal [["~> 2.6.0"], {:engine=>nil, :engine_version=>nil}], result.ruby.first
+  end
+
+  def test_ruby_version_specifiers
+    Gel::GemfileParser::RunningRuby.expects(:version).returns("2.9.9")
+
+    result = Gel::GemfileParser.parse(<<GEMFILE, __FILE__, __LINE__ + 1)
+source "https://rubygems.org"
+
+ruby ">= 2.3.0", "< 3.0.0"
+GEMFILE
+
+    assert_equal [[">= 2.3.0", "< 3.0.0"], {:engine=>nil, :engine_version=>nil}], result.ruby.first
+  end
 end


### PR DESCRIPTION
This Pull Request is for #56.

- Extract into `RunningRuby` in order to stub the constant in tests
- [x] Tests are passing
  ```
  bin/setup && bin/rake
  ```
- [ ] I manually tested `gel install`  with these changes work locally in a project
  ```
  /Users/juanitofatas/src/github.com/matthewd/gel/exe/gel install
  ```
  Not related to the changes from this Pull Request, but I am having a weird issue that throws an error at local (See https://github.com/gel-rb/gel/issues/61)

