### PR TITLE
Add support to parse RUBY VERSION in Lock parser and a test for resolved gem set

### DIFF
--- a/lib/gel/lock_parser.rb
+++ b/lib/gel/lock_parser.rb
@@ -53,6 +53,13 @@ class Gel::LockParser
           content << entry
           scanner.skip(/\n/)
         end
+      when "RUBY VERSION"
+        content = []
+        while scanner.skip(/^   \b/)
+          entry = scanner.scan(/.*/)
+          content << entry
+          scanner.skip(/\n/)
+        end
       end
       scanner.skip(/\n+/)
 

--- a/test/lock_parser_test.rb
+++ b/test/lock_parser_test.rb
@@ -36,6 +36,9 @@ DEPENDENCIES
   rake
   rubocop-rails
 
+RUBY VERSION
+   ruby 2.6.3p62
+
 BUNDLED WITH
    1.15.4
 LOCKFILE
@@ -66,6 +69,7 @@ LOCKFILE
         ] }],
       ["PLATFORMS", ["ruby"]],
       ["DEPENDENCIES", ["minitest", "rake", "rubocop-rails"]],
+      ["RUBY VERSION", ["ruby 2.6.3p62"]],
       ["BUNDLED WITH", ["1.15.4"]],
     ], parser.parse(EXAMPLE)
   end

--- a/test/resolved_gem_set_test.rb
+++ b/test/resolved_gem_set_test.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+require "tempfile"
+require "gel/resolved_gem_set"
+
+class ResolvedGemSetTest < Minitest::Test
+  EXAMPLE = <<LOCKFILE
+GEM
+  remote: https://rubygems.org/
+  specs:
+    gel (0.3.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  gel
+
+RUBY VERSION
+   ruby 2.4.0p0
+
+BUNDLED WITH
+   1.17.3
+LOCKFILE
+
+  def test_load
+    lockfile = Tempfile.new
+    lockfile.write(EXAMPLE)
+    lockfile.close
+
+    result = Gel::ResolvedGemSet.load(lockfile.path)
+
+    assert_equal 1, result.gems.count
+    assert_equal ["ruby"], result.platforms
+    assert_equal ["gel"], result.dependencies
+    assert_equal "ruby 2.4.0p0", result.ruby_version
+    assert_equal "1.17.3", result.bundler_version
+    assert_kind_of Gel::Catalog, result.server_catalogs.first
+  end
+end


### PR DESCRIPTION
This PR adds support of parsing `RUBY VERSION` of lockfile to `LockParser` and a test for `Gel::ResolvedGemSet`.

- [x] Tests are passing

  ```
  bin/setup && bin/rake
  ```