### PR TITLE
Fix resolving gem when there is no lockfile

### DIFF
--- a/lib/gel/resolved_gem_set.rb
+++ b/lib/gel/resolved_gem_set.rb
@@ -114,7 +114,8 @@ class Gel::ResolvedGemSet
         next if resolved_gem.name == "bundler" || resolved_gem.name == "ruby"
 
         lock_content << "    #{resolved_gem.name} (#{resolved_gem.full_version})"
-        resolved_gem.deps.sort.each do |dep_name, dep_reqs|
+        sorted_deps = resolved_gem.deps.sort_by { |dep_name, dep_reqs| dep_name }
+        sorted_deps.each do |dep_name, dep_reqs|
           if dep_reqs
             lock_content << "      #{dep_name} (#{dep_reqs})"
           else

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -184,3 +184,7 @@ def capture_stdout
 ensure
   $stdout = original_stdout
 end
+
+def assert_nothing_raised
+  yield
+end


### PR DESCRIPTION
This Pull Request fixes #65.

- Added a test helper method `assert_nothing_raised` 5a9fec7
- Fix the bug in `dump` 5a9fec7...f99c1e1
- The test is the minimum to reproduce the failure, not being able to resolve the whole lockfile.
- [x] Tests are passing
   ```
  bin/setup && bin/rake
  ```

- [x] I tested changes in this Pull Request against a local project