### PR TITLE
Add default config command

### DIFF
--- a/lib/gel/command/config.rb
+++ b/lib/gel/command/config.rb
@@ -2,7 +2,12 @@
 
 class Gel::Command::Config < Gel::Command
   def run(command_line)
-    if command_line.size == 1
+    if command_line.empty?
+      Gel::Environment.config.all.each do |key,_|
+        value = Gel::Environment.config[key]
+        puts "#{key}=#{value}"
+      end
+    elsif command_line.size == 1
       puts Gel::Environment.config[command_line.first]
     else
       Gel::Environment.config[command_line.shift] = command_line.join(" ")

--- a/lib/gel/config.rb
+++ b/lib/gel/config.rb
@@ -2,13 +2,21 @@
 
 class Gel::Config
   def initialize
-    @root = File.expand_path("~/.config/gel")
+    @root = file_path
     @path = File.join(@root, "config")
     @config = nil
   end
 
   def config
     @config ||= read
+  end
+
+  def all
+    config
+  end
+
+  def file_path
+    File.expand_path("~/.config/gel")
   end
 
   def [](group = nil, key)

--- a/test/command/config_test.rb
+++ b/test/command/config_test.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ConfigTest < Minitest::Test
+  def test_default_config
+    # poor mans mocking when config is called, we use a path within the test
+    output = capture_stdout { Gel::Command::Config.run(["config"]) }
+
+    assert_equal 0, Gel::Environment.config.all
+  end
+end


### PR DESCRIPTION
Adding a default config command so we can use gel like so;

`gel config`

Which will output all the default config settings, e.g.

jobs=3
gem.test=minitest
gem.mit=true

- [ ] Add tests that write to a config file inside fixtures