### PR TITLE
Implement `install_if` processing

### DIFF
--- a/lib/gel/environment.rb
+++ b/lib/gel/environment.rb
@@ -435,7 +435,12 @@ class Gel::Environment
 
   def self.filtered_gems(gems = self.gemfile.gems)
     platforms = GEMFILE_PLATFORMS.map(&:to_s)
-    gems = gems.reject { |g| g[2][:platforms] && (Array(g[2][:platforms]).map(&:to_s) & platforms).empty? }
+    gems = gems.reject do |_, _, options|
+      platform_options = Array(options[:platforms]).map(&:to_s)
+
+      next true if platform_options.any? && (platform_options & platforms).empty?
+      next true unless options.fetch(:install_if, true)
+    end
     gems
   end
 

--- a/test/gemfile_parser_test.rb
+++ b/test/gemfile_parser_test.rb
@@ -140,4 +140,28 @@ GEMFILE
 
     assert_equal [[">= 2.3.0", "< 3.0.0"], {:engine=>nil, :engine_version=>nil}], result.ruby.first
   end
+
+
+  def test_install_if
+    result = Gel::GemfileParser.parse(<<GEMFILE, __FILE__, __LINE__ + 1)
+source "https://rubygems.org"
+install_if true do
+  gem "activesupport", "2.3.5"
+end
+gem "thin", :install_if => lambda { false }
+install_if lambda { false } do
+  gem "foo"
+end
+gem "bar", :install_if => [true, lambda { 1 }]
+gem "rack"
+GEMFILE
+
+    assert_equal [
+      ["activesupport", ["2.3.5"],  { install_if: true }],
+      ["thin",          [],         { install_if: false }],
+      ["foo",           [],         { install_if: false }],
+      ["bar",           [],         { install_if: true }],
+      ["rack",          [],         {}],
+    ], result.gems
+  end
 end

--- a/test/lock_activate_test.rb
+++ b/test/lock_activate_test.rb
@@ -90,8 +90,12 @@ LOCKFILE
 
   def test_ignore_gems_excluded_by_gemfile
     gemfile_content = <<GEMFILE
-gem "rack"
+gem "rack", install_if: true
 gem "rack-test", platforms: :rbx
+gem "hoe", install_if: false
+install_if ->{ false } do
+  gem "atomic"
+end
 GEMFILE
 
     lockfile = Tempfile.new("")
@@ -99,6 +103,8 @@ GEMFILE
 GEM
   remote: https://rubygems.org/
   specs:
+    atomic (1.1.16)
+    hoe (3.0.0)
     rack (2.0.3)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -109,7 +115,7 @@ DEPENDENCIES
 LOCKFILE
     lockfile.close
 
-    with_fixture_gems_installed(["rack-test-0.6.3.gem", "rack-2.0.3.gem", "hoe-3.0.0.gem"]) do |store|
+    with_fixture_gems_installed(["rack-test-0.6.3.gem", "rack-2.0.3.gem", "hoe-3.0.0.gem", "atomic-1.1.16.gem"]) do |store|
       output = subprocess_output(<<-'END', store: store, lock_path: lockfile.path, gemfile_content: gemfile_content)
         loader = Gel::LockLoader.new(lock_path, Gel::GemfileParser.parse(gemfile_content))
         loader.activate(Gel::Environment, store)


### PR DESCRIPTION
`install_if` is [a poorly documented](https://bundler.io/man/gemfile.5.html#INSTALL_IF) Gemfile method, but it actually has the following behaviours:
1. It accepts multiple conditions that all have to evaluate to true for the gem to be installed
2. It has both a block form and an inline form that operate in the same fashion.
3. Any gem that is ultimately marked as `install_if: false` is considered during resolution but is filtered as an install candidate (similar to how `platforms` works)

This PR aims to add support for all those behaviours inline with the Gel workflow:
1. `install_if` methods are converted to options on the current stack for block-form usages and merged with inline usages. 
2. When adding a gem to the list of resolved gems, the `install_if` conditions collected in the previous step are evaluated and converted to a final boolean value. 
3. When gems are being filtered, a check for the now-boolean `install_if` condition is performed to decide to filter the gem or not.

Fixes #63