### PR TITLE
Allow multilevel values for `group`, `platforms` and `install_if`

### DIFF
--- a/lib/gel/gemfile_parser.rb
+++ b/lib/gel/gemfile_parser.rb
@@ -143,13 +143,21 @@ module Gel::GemfileParser
     def flatten(options, stack)
       options = options.dup
       stack.reverse_each do |layer|
-        options.update(layer) { |_, current, outer| current }
+        options.update(layer) { |_, current, outer| Array(outer) + Array(current) }
       end
+
       @git_sources.each do |key, block|
         next unless options.key?(key)
         raise "Multiple git sources specified" if options.key?(:git)
         options[:git] = block.call(options.delete(key))
       end
+
+      if options[:install_if]
+        options[:install_if] = Array(options[:install_if]).all? do |condition|
+          condition.respond_to?(:call) ? condition.call : condition
+        end
+      end
+
       options
     end
 
@@ -157,12 +165,6 @@ module Gel::GemfileParser
       return if name == "bundler"
       raise "Only git sources can specify a :branch" if options[:branch] && !options[:git]
       raise "Duplicate entry for gem #{name.inspect}" if @gems.assoc(name)
-
-      if options[:install_if]
-        options[:install_if] = Array(options[:install_if]).all? do |condition|
-          condition.respond_to?(:call) ? condition.call : condition
-        end
-      end
 
       @gems << [name, requirements, options]
     end

--- a/test/gemfile_parser_test.rb
+++ b/test/gemfile_parser_test.rb
@@ -19,11 +19,11 @@ group :doc do
 end
 
 group :test do
-  gem "minitest-bisect"
+  gem "minitest-bisect", group: :development
 
   platforms :mri do
     gem "stackprof"
-    gem "byebug"
+    gem "byebug", platforms: :rbx
   end
 
   gem "benchmark-ips"
@@ -42,10 +42,10 @@ GEMFILE
       ["rake", [">= 11.1"], {}],
       ["mocha", [], require: false],
       ["bcrypt", ["~> 3.1.11"], require: false],
-      ["w3c_validators", [], group: [:doc], require: "w3c_validators/validator"],
-      ["minitest-bisect", [], group: [:test]],
+      ["w3c_validators", [], require: "w3c_validators/validator", group: [:doc]],
+      ["minitest-bisect", [], group: [:test, :development]],
       ["stackprof", [], platforms: [:mri], group: [:test]],
-      ["byebug", [], platforms: [:mri], group: [:test]],
+      ["byebug", [], platforms: [:mri, :rbx], group: [:test]],
       ["benchmark-ips", [], group: [:test]],
       ["rails-assets-bootstrap", [], source: "https://rails-assets.org"],
     ], result.gems
@@ -149,8 +149,8 @@ install_if true do
   gem "activesupport", "2.3.5"
 end
 gem "thin", :install_if => lambda { false }
-install_if lambda { false } do
-  gem "foo"
+install_if true, lambda { nil } do
+  gem "foo", :install_if => true
 end
 gem "bar", :install_if => [true, lambda { 1 }]
 gem "rack"


### PR DESCRIPTION
So far, Gel has been using only the nearest value defined in a Gemfile for `group`, `platforms` and `install_if` options, disregarding any values supplied in surrounding contexts. However, Bundler actually merges all the values in all the contexts.

This PR is an initial naive attempt to resolve the behaviour difference between the two. It assumes that all such options are Array valued and it just blindly collects all the Array values together.

I would be grateful if I can get comments on the general direction and/or possible improvements on implementation and testing.