### PR TITLE
Add gel/errors to gel.rb

### DIFF
--- a/lib/gel.rb
+++ b/lib/gel.rb
@@ -15,6 +15,7 @@ require_relative "gel/store_gem"
 require_relative "gel/direct_gem"
 require_relative "gel/locked_store"
 require_relative "gel/multi_store"
+require_relative "gel/error"
 
 require_relative "gel/gemspec_parser"
 require_relative "gel/gemfile_parser"


### PR DESCRIPTION
Ran the command `bin/console` in my Sinatra based app whilst having gel setup in my path, and ran into a missing require error;

```
Traceback (most recent call last):
8: from bin/console:3:in `<main>'
7: from /Users/haroon/projects/gel/lib/gel/compatibility/rubygems.rb:197:in `require'
6: from /Users/haroon/projects/gel/lib/gel/compatibility/rubygems.rb:197:in `require'
5: from /Users/haroon/projects/gel/lib/gel/compatibility/bundler/setup.rb:4:in `<top (required)>'
4: from /Users/haroon/projects/gel/lib/gel/compatibility/bundler.rb:5:in `setup'
3: from /Users/haroon/projects/gel/lib/gel/environment.rb:355:in `activate'
2: from /Users/haroon/projects/gel/lib/gel/environment.rb:97:in `load_gemfile'
1: from /Users/haroon/projects/gel/lib/gel/gemfile_parser.rb:4:in `parse'
/Users/haroon/projects/gel/lib/gel/gemfile_parser.rb:14:in `rescue in parse': uninitialized constant Gel::Error (NameError)
```