### PR TITLE
Fix shadowing outer local variable warnings

### DIFF
--- a/lib/gel/installer.rb
+++ b/lib/gel/installer.rb
@@ -143,9 +143,9 @@ class Gel::Installer
     synchronize do
       compile_recheck, @compile_waiting = @compile_waiting, []
 
-      compile_recheck.each do |g|
-        @compile_pool.queue(g.spec.name) do
-          work_compile(g)
+      compile_recheck.each do |gem|
+        @compile_pool.queue(gem.spec.name) do
+          work_compile(gem)
         end
       end
     end

--- a/lib/gel/store_catalog.rb
+++ b/lib/gel/store_catalog.rb
@@ -17,8 +17,8 @@ class Gel::StoreCatalog
 
     @store.each(name) do |store_gem|
       info[store_gem.version] = {
-        dependencies: store_gem.dependencies.map do |name, pairs|
-          [name, pairs.map { |op, ver| "#{op} #{ver}" }]
+        dependencies: store_gem.dependencies.map do |dependency, pairs|
+          [dependency, pairs.map { |op, ver| "#{op} #{ver}" }]
         end,
       }
     end


### PR DESCRIPTION
This Pull Request fixes warnings spotted from [Build #244](https://buildkite.com/matthewd/gel/builds/224#0f59c415-b035-4bfd-97b7-d7d75b9a57de):


```
# Running:
|  
| ............../app/lib/gel/store_catalog.rb:20: warning: shadowing outer local variable - name
| /root/.local/gel/ruby/gems/pub_grub-0.5.0/lib/pub_grub/partial_solution.rb:38: warning: shadowing outer local variable - assignment
| ...........S........................................./app/lib/gel/installer.rb:146: warning: shadowing outer local variable - g
| ./app/lib/gel/installer.rb:146: warning: shadowing outer local variable - g
| ...
|  
| Finished in 21.411552s, 3.3160 runs/s, 13.0303 assertions/s.
|  
| 71 runs, 279 assertions, 0 failures, 0 errors, 1 skips
```