### PR TITLE
Add `extra_rdoc_files` to the gemspec parser

### DIFF
--- a/lib/gel/gemspec_parser.rb
+++ b/lib/gel/gemspec_parser.rb
@@ -37,6 +37,7 @@ class Gel::GemspecParser
       self.metadata = {}
       self.requirements = []
       self.rdoc_options = []
+      self.extra_rdoc_files = []
       self.development_dependencies = []
       self.runtime_dependencies = []
       self.executables = []

--- a/test/gemspec_parser_test.rb
+++ b/test/gemspec_parser_test.rb
@@ -48,4 +48,10 @@ GEMSPEC
     assert gemspec.files.include?("lib/gel/gemspec_parser.rb")
     assert_equal [["rake", ["~> 10.0"]], ["minitest", ["~> 5.0"]]], gemspec.development_dependencies
   end
+
+  def test_spec_with_extra_rdoc_files
+    result = Gel::GemspecParser::Result.new
+    result.extra_rdoc_files += ["README.md"]
+    assert_equal ["README.md"], result.extra_rdoc_files
+  end
 end


### PR DESCRIPTION
This option was seen in the wild here:

  https://github.com/codahale/bcrypt-ruby/blob/master/bcrypt.gemspec

After this patch, it works:

```
[aaron@TC ~/g/bcrypt-ruby (update-deps)]$ ruby --disable-gems -I ~/git/gel/lib ~/git/gel/bin/gel install
Installing rspec-support (3.8.0)
Installing diff-lcs (1.3)
Installing rake-compiler (0.9.9)
Installing rspec-mocks (3.8.0)
Installing rspec-expectations (3.8.3)
Installing rspec (3.8.0)
Installing rspec-core (3.8.0)
Installed 7 gems
```