### PR TITLE
Fix missing Gem namespace

### DIFF
--- a/lib/gel/catalog/marshal_hacks.rb
+++ b/lib/gel/catalog/marshal_hacks.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+module Gem; end unless defined? Gem
+
 class Gem::Specification
   class Unmarshalled
     attr_accessor :required_ruby_version


### PR DESCRIPTION
The Gem namespace may not have been defined yet as this file gets loaded just before the rubygems compatibility layer. This could be moved into the compatibility layer, but it seems to have been separated so that it is independently loadable. So maybe this is better? Fixes #79.