### PR TITLE
Write count after writing the counted

### DIFF
--- a/lib/gel/db.rb
+++ b/lib/gel/db.rb
@@ -208,10 +208,10 @@ class Gel::DB::SDBM < Gel::DB
 
     if count > 0
       count += 1
-      @sdbm["#{key.to_s}"] = "~#{count}"
       count.times.map do |idx|
         @sdbm["#{key.to_s}#{SAFE_DELIMITER}#{idx}"] = dump.slice!(0, SDBM_MAX_STORE_SIZE)
       end
+      @sdbm["#{key.to_s}"] = "~#{count}"
     else
       @sdbm[key.to_s] = dump
     end

--- a/test/db_test.rb
+++ b/test/db_test.rb
@@ -25,6 +25,10 @@ class DbTest < Minitest::Test
       db['test'] = long_string
       assert_equal db['test'], long_string
 
+      # Long keys must be storable, too
+      db[long_string] = long_string
+      assert_equal db[long_string], long_string
+
       # A object with a long string gets stored and marshaled correctly
       hash_string = { a: long_string, b: long_string }
       db['test'] = hash_string


### PR DESCRIPTION
Prevent a race condition where one process might write a count of entries then still be writing the counted entries when another process reads the count and starts reading the counted entries at the same time. Maybe. If the processes fork poorly, and share file descriptors, or something.