### PR TITLE
SDBM split size

### DIFF
--- a/lib/gel/db.rb
+++ b/lib/gel/db.rb
@@ -208,10 +208,10 @@ class Gel::DB::SDBM < Gel::DB
 
     if count > 0
       count += 1
-      @sdbm["#{key.to_s}"] = "~#{count}"
       count.times.map do |idx|
         @sdbm["#{key.to_s}#{SAFE_DELIMITER}#{idx}"] = dump.slice!(0, SDBM_MAX_STORE_SIZE)
       end
+      @sdbm["#{key.to_s}"] = "~#{count}"
     else
       @sdbm[key.to_s] = dump
     end

--- a/test/db_test.rb
+++ b/test/db_test.rb
@@ -21,7 +21,7 @@ class DbTest < Minitest::Test
       assert_equal db['test'], { a: 'Hello World' }
 
       # A string that will be split up over multiple stores
-      long_string = '*' * (Gel::DB::SDBM::SDBM_MAX_STORE_SIZE + 200)
+      long_string = '*' * (Gel::DB::SDBM::SDBM_PAIRMAX + 200)
       db['test'] = long_string
       assert_equal db['test'], long_string
 

--- a/test/db_test.rb
+++ b/test/db_test.rb
@@ -25,6 +25,11 @@ class DbTest < Minitest::Test
       db['test'] = long_string
       assert_equal db['test'], long_string
 
+      # Long keys must be storable, too
+      long_key = "*" * 200
+      db[long_key] = long_string
+      assert_equal db[long_key], long_string
+
       # A object with a long string gets stored and marshaled correctly
       hash_string = { a: long_string, b: long_string }
       db['test'] = hash_string


### PR DESCRIPTION
SDBM's limits are on the key/value pair, not on the value alone. This adjusts the split algorithm to factor in key size as well for a dynamic split size.