### PR TITLE
Fix Gel::DB::File with special char keys

### DIFF
--- a/lib/gel/db.rb
+++ b/lib/gel/db.rb
@@ -267,28 +267,38 @@ class Gel::DB::File < Gel::DB
   end
 
   def each_key
-    @path.each_child(false) do |child|
-      yield child.to_s
+    Dir.each_child(@path) do |child|
+      yield unmangle(child)
     end
   end
 
   def key?(key)
-    @path.join(key).exist?
+    @path.join(mangle(key)).exist?
   end
 
   def [](key)
-    child = @path.join(key)
+    child = @path.join(mangle(key))
     if child.exist?
       Marshal.load(child.binread)
     end
   end
 
   def []=(key, value)
-    child = @path.join(key)
+    child = @path.join(mangle(key))
     if value
       child.binwrite Marshal.dump(value)
     elsif child.exist?
       child.unlink
     end
+  end
+
+  private
+
+  def mangle(key)
+    [key].pack("m").chomp
+  end
+
+  def unmangle(filename)
+    filename.unpack1("m")
   end
 end

--- a/test/db_test.rb
+++ b/test/db_test.rb
@@ -31,4 +31,32 @@ class DbTest < Minitest::Test
       assert_equal db['test'], hash_string
     end
   end
+
+  def test_file_store_value_retrieval
+    Dir.mktmpdir do |dir|
+      db = Gel::DB::File.new(dir, 'test-store')
+
+      # Still handles ints okay
+      db['test'] = 12
+      assert_equal db['test'], 12
+
+      # A simple string should return a simple string
+      db['test'] = 'Hello World'
+      assert_equal db['test'], 'Hello World'
+
+      # A simple hash should return a simple hash
+      db['test'] = { a: 'Hello World' }
+      assert_equal db['test'], { a: 'Hello World' }
+
+      # A long string
+      long_string = '*' * 1024
+      db['test'] = long_string
+      assert_equal db['test'], long_string
+
+      # A object with a long string gets stored and marshaled correctly
+      hash_string = { a: long_string, b: long_string }
+      db['test'] = hash_string
+      assert_equal db['test'], hash_string
+    end
+  end
 end

--- a/test/db_test.rb
+++ b/test/db_test.rb
@@ -57,6 +57,10 @@ class DbTest < Minitest::Test
       hash_string = { a: long_string, b: long_string }
       db['test'] = hash_string
       assert_equal db['test'], hash_string
+
+      # A key with a slash works
+      db['foo/bar'] = hash_string
+      assert_equal db['foo/bar'], hash_string
     end
   end
 end


### PR DESCRIPTION
The Gel File DB is currently unusable beyond very simple keys because it doesn't handle keys which contain slashes "/" or other special characters which Gel now uses in abundance. This is a simple solve which mangles keys with base64 before using them as filenames. It works great.

From basic testing, the file store is several OOM faster than PStore, but still just under an OOM slower than SDBM.