### PR TITLE
Fix: Gel::Pinboard#read may return nil

### DIFF
--- a/lib/gel/pinboard.rb
+++ b/lib/gel/pinboard.rb
@@ -117,7 +117,8 @@ class Gel::Pinboard
   def updated(uri, etag, changed = true)
     blocks = nil
     @monitor.synchronize do
-      @db[uri.to_s] = read(uri).merge(etag: etag, stale: false)
+      h = read(uri) || {}
+      @db[uri.to_s] = h.merge(etag: etag, stale: false)
 
       blocks = @waiting.delete(uri)
     end


### PR DESCRIPTION
```
% gel install
Fetching sources....Unhandled exception in work pool "gel-catalog-prep" for job "catalog":
   .../gel/lib/gel/pinboard.rb:122:in `block in updated'
   /usr/local/rbenv/versions/2.6.2/lib/ruby/2.6.0/monitor.rb:230:in `mon_synchronize'
   .../gel/lib/gel/pinboard.rb:121:in `updated'
   .../gel/lib/gel/tail_file.rb:98:in `block (2 levels) in update'
   .../gel/lib/gel/tail_file.rb:45:in `times'
   .../gel/lib/gel/tail_file.rb:45:in `block in update'
   .../gel/lib/gel/tail_file.rb:42:in `open'
   .../gel/lib/gel/tail_file.rb:42:in `update'
   .../gel/lib/gel/pinboard.rb:58:in `block (2 levels) in async_file'
   .../gel/lib/gel/work_pool.rb:62:in `block (4 levels) in start'
   .../gel/lib/gel/work_pool.rb:47:in `loop'
   .../gel/lib/gel/work_pool.rb:47:in `block (3 levels) in start'
   .../gel/lib/gel/work_pool.rb:46:in `catch'
   .../gel/lib/gel/work_pool.rb:46:in `block (2 levels) in start'

Resolving dependencies...

===== Gel Internal Error =====

Traceback (most recent call last):
	13: from .../gel/lib/gel/work_pool.rb:46:in `block (2 levels) in start'
	12: from .../gel/lib/gel/work_pool.rb:46:in `catch'
	11: from .../gel/lib/gel/work_pool.rb:47:in `block (3 levels) in start'
	10: from .../gel/lib/gel/work_pool.rb:47:in `loop'
	 9: from .../gel/lib/gel/work_pool.rb:62:in `block (4 levels) in start'
	 8: from .../gel/lib/gel/pinboard.rb:58:in `block (2 levels) in async_file'
	 7: from .../gel/lib/gel/tail_file.rb:42:in `update'
	 6: from .../gel/lib/gel/tail_file.rb:42:in `open'
	 5: from .../gel/lib/gel/tail_file.rb:45:in `block in update'
	 4: from .../gel/lib/gel/tail_file.rb:45:in `times'
	 3: from .../gel/lib/gel/tail_file.rb:98:in `block (2 levels) in update'
	 2: from .../gel/lib/gel/pinboard.rb:121:in `updated'
	 1: from /usr/local/rbenv/versions/2.6.2/lib/ruby/2.6.0/monitor.rb:230:in `mon_synchronize'
.../gel/lib/gel/pinboard.rb:122:in `block in updated': undefined method `merge' for nil:NilClass (NoMethodError)
```