### PR TITLE
Print the log file path so that we can debug what is wrong

### DIFF
--- a/lib/gel/package/installer.rb
+++ b/lib/gel/package/installer.rb
@@ -166,10 +166,10 @@ class Gel::Package::Installer
         # Ignore exit status
 
         status = build_command(work_dir, log, "make", "-j3", "DESTDIR=")
-        raise "make exited with #{status.exitstatus}" unless status.success?
+        raise "make exited with #{status.exitstatus}\n Check #{log.path} for more details" unless status.success?
 
         status = build_command(work_dir, log, "make", "install", "DESTDIR=")
-        raise "make install exited with #{status.exitstatus}" unless status.success?
+        raise "make exited with #{status.exitstatus}\n Check #{log.path} for more details" unless status.success?
       end
     end
 


### PR DESCRIPTION
One gem is failing to install, but I didn't know what was wrong.  Before
this change, the output would look like this:

```
[aaron@tc-lan-adapter ~/g/active_record_has_many_split_through (matrix)]$ gel install
Installed 0 of 1 gems

Errors encountered with 1 gems:

byebug
  make exited with 69

===== Gel Internal Error =====

Traceback (most recent call last):
	14: from /Users/aaron/.rbenv/versions/ruby-trunk/lib/ruby/gems/2.7.0/gems/gel-0.3.0/lib/gel/work_pool.rb:46:in `block (2 levels) in start'
	13: from /Users/aaron/.rbenv/versions/ruby-trunk/lib/ruby/gems/2.7.0/gems/gel-0.3.0/lib/gel/work_pool.rb:46:in `catch'
	12: from /Users/aaron/.rbenv/versions/ruby-trunk/lib/ruby/gems/2.7.0/gems/gel-0.3.0/lib/gel/work_pool.rb:47:in `block (3 levels) in start'
	11: from /Users/aaron/.rbenv/versions/ruby-trunk/lib/ruby/gems/2.7.0/gems/gel-0.3.0/lib/gel/work_pool.rb:47:in `loop'
	10: from /Users/aaron/.rbenv/versions/ruby-trunk/lib/ruby/gems/2.7.0/gems/gel-0.3.0/lib/gel/work_pool.rb:62:in `block (4 levels) in start'
	 9: from /Users/aaron/.rbenv/versions/ruby-trunk/lib/ruby/gems/2.7.0/gems/gel-0.3.0/lib/gel/installer.rb:118:in `block (2 levels) in work_download'
	 8: from /Users/aaron/.rbenv/versions/ruby-trunk/lib/ruby/gems/2.7.0/gems/gel-0.3.0/lib/gel/installer.rb:134:in `work_compile'
	 7: from /Users/aaron/.rbenv/versions/ruby-trunk/lib/ruby/gems/2.7.0/gems/gel-0.3.0/lib/gel/package/installer.rb:206:in `compile'
	 6: from /Users/aaron/.rbenv/versions/ruby-trunk/lib/ruby/gems/2.7.0/gems/gel-0.3.0/lib/gel/package/installer.rb:206:in `each'
	 5: from /Users/aaron/.rbenv/versions/ruby-trunk/lib/ruby/gems/2.7.0/gems/gel-0.3.0/lib/gel/package/installer.rb:209:in `block in compile'
	 4: from /Users/aaron/.rbenv/versions/ruby-trunk/lib/ruby/gems/2.7.0/gems/gel-0.3.0/lib/gel/package/installer.rb:154:in `compile_extconf'
	 3: from /Users/aaron/.rbenv/versions/ruby-trunk/lib/ruby/gems/2.7.0/gems/gel-0.3.0/lib/gel/package/installer.rb:88:in `with_build_environment'
	 2: from /Users/aaron/.rbenv/versions/ruby-trunk/lib/ruby/gems/2.7.0/gems/gel-0.3.0/lib/gel/package/installer.rb:88:in `open'
	 1: from /Users/aaron/.rbenv/versions/ruby-trunk/lib/ruby/gems/2.7.0/gems/gel-0.3.0/lib/gel/package/installer.rb:89:in `block in with_build_environment'
/Users/aaron/.rbenv/versions/ruby-trunk/lib/ruby/gems/2.7.0/gems/gel-0.3.0/lib/gel/package/installer.rb:169:in `block in compile_extconf': make exited with 69 (RuntimeError)
```

After this change the output looks like this:

```
[aaron@tc-lan-adapter ~/g/active_record_has_many_split_through (matrix)]$ gel install
Installed 0 of 1 gems

Errors encountered with 1 gems:

byebug
  make exited with 69
Check /Users/aaron/.local/gel/2.7.0/ext/byebug-10.0.2/build.log for more details

===== Gel Internal Error =====

Traceback (most recent call last):
	14: from /Users/aaron/.rbenv/versions/ruby-trunk/lib/ruby/gems/2.7.0/gems/gel-0.3.0/lib/gel/work_pool.rb:46:in `block (2 levels) in start'
	13: from /Users/aaron/.rbenv/versions/ruby-trunk/lib/ruby/gems/2.7.0/gems/gel-0.3.0/lib/gel/work_pool.rb:46:in `catch'
	12: from /Users/aaron/.rbenv/versions/ruby-trunk/lib/ruby/gems/2.7.0/gems/gel-0.3.0/lib/gel/work_pool.rb:47:in `block (3 levels) in start'
	11: from /Users/aaron/.rbenv/versions/ruby-trunk/lib/ruby/gems/2.7.0/gems/gel-0.3.0/lib/gel/work_pool.rb:47:in `loop'
	10: from /Users/aaron/.rbenv/versions/ruby-trunk/lib/ruby/gems/2.7.0/gems/gel-0.3.0/lib/gel/work_pool.rb:62:in `block (4 levels) in start'
	 9: from /Users/aaron/.rbenv/versions/ruby-trunk/lib/ruby/gems/2.7.0/gems/gel-0.3.0/lib/gel/installer.rb:118:in `block (2 levels) in work_download'
	 8: from /Users/aaron/.rbenv/versions/ruby-trunk/lib/ruby/gems/2.7.0/gems/gel-0.3.0/lib/gel/installer.rb:134:in `work_compile'
	 7: from /Users/aaron/.rbenv/versions/ruby-trunk/lib/ruby/gems/2.7.0/gems/gel-0.3.0/lib/gel/package/installer.rb:206:in `compile'
	 6: from /Users/aaron/.rbenv/versions/ruby-trunk/lib/ruby/gems/2.7.0/gems/gel-0.3.0/lib/gel/package/installer.rb:206:in `each'
	 5: from /Users/aaron/.rbenv/versions/ruby-trunk/lib/ruby/gems/2.7.0/gems/gel-0.3.0/lib/gel/package/installer.rb:209:in `block in compile'
	 4: from /Users/aaron/.rbenv/versions/ruby-trunk/lib/ruby/gems/2.7.0/gems/gel-0.3.0/lib/gel/package/installer.rb:154:in `compile_extconf'
	 3: from /Users/aaron/.rbenv/versions/ruby-trunk/lib/ruby/gems/2.7.0/gems/gel-0.3.0/lib/gel/package/installer.rb:88:in `with_build_environment'
	 2: from /Users/aaron/.rbenv/versions/ruby-trunk/lib/ruby/gems/2.7.0/gems/gel-0.3.0/lib/gel/package/installer.rb:88:in `open'
	 1: from /Users/aaron/.rbenv/versions/ruby-trunk/lib/ruby/gems/2.7.0/gems/gel-0.3.0/lib/gel/package/installer.rb:89:in `block in with_build_environment'
/Users/aaron/.rbenv/versions/ruby-trunk/lib/ruby/gems/2.7.0/gems/gel-0.3.0/lib/gel/package/installer.rb:169:in `block in compile_extconf': make exited with 69 (RuntimeError)
Check /Users/aaron/.local/gel/2.7.0/ext/byebug-10.0.2/build.log for more details
```

Also, I don't think this should be considered a "gel internal error" as
it's not really a problem with gel, but a problem with my system (I need
to agree to the xcode license thing and that's why the build is failing)