### PR TITLE
Provide enough empty shells that rake-compiler can (partly) work

### DIFF
--- a/lib/gel/compatibility/rubygems.rb
+++ b/lib/gel/compatibility/rubygems.rb
@@ -32,6 +32,10 @@ module Gem
       include Enumerable
     end
 
+    def self.load(filename)
+      new(Gel::DirectGem.new(File.dirname(filename), File.basename(filename, ".gemspec")))
+    end
+
     def self.find_by_name(name, *requirements)
       if g = Gel::Environment.find_gem(name, *requirements)
         new(g)
@@ -75,6 +79,14 @@ module Gem
       @store_gem.require_paths.map do |path|
         Pathname.new(path).relative_path_from(base).to_s
       end
+    end
+
+    def platform
+      nil
+    end
+
+    def files
+      []
     end
   end
 

--- a/lib/gel/compatibility/rubygems/package_task.rb
+++ b/lib/gel/compatibility/rubygems/package_task.rb
@@ -1,0 +1,7 @@
+class Gem::PackageTask
+  def initialize(*)
+  end
+
+  def method_missing(*)
+  end
+end

--- a/lib/gel/direct_gem.rb
+++ b/lib/gel/direct_gem.rb
@@ -20,10 +20,10 @@ class Gel::DirectGem < Gel::StoreGem
     info = {
       bindir: gemspec.bindir || "bin",
       executables: gemspec.executables,
-      require_paths: gemspec.require_paths || [gemspec.require_path].compact,
+      require_paths: gemspec.require_paths || [gemspec.require_path || "lib"].compact,
       dependencies: gemspec.runtime_dependencies,
     }
 
-    super(root, name, version || Gel::Support::GemVersion.new(gemspec.version).to_s, gemspec.extensions, info)
+    super(root, name, version || Gel::Support::GemVersion.new(gemspec.version).to_s, nil, info)
   end
 end


### PR DESCRIPTION
We're currently still not aiming to be able to produce a packaged gem -- but we can fake out the parts rake-compiler needs while it's just trying to set up its rake tasks.

The goal is to allow a rake-compiler-using gem (such as Puma) to work in local use, and support `rake compile`, under Gel. Actual packaging for distribution is best left to Bundler & Rubygems.

Fixes #77