### PR TITLE
Fix ruby 2.7 deprecations

### DIFF
--- a/lib/gel/catalog/compact_index.rb
+++ b/lib/gel/catalog/compact_index.rb
@@ -10,8 +10,8 @@ class Gel::Catalog::CompactIndex
   include Gel::Catalog::Common
   CACHE_TYPE = "index"
 
-  def initialize(*)
-    super
+  def initialize(*args, **kwargs)
+    super(*args, **kwargs)
 
     @gem_tokens = Hash.new("NONE")
     @needs_update = true

--- a/lib/gel/catalog/dependency_index.rb
+++ b/lib/gel/catalog/dependency_index.rb
@@ -15,8 +15,8 @@ class Gel::Catalog::DependencyIndex
 
   LIST_MAX = 40
 
-  def initialize(catalog, *args)
-    super(*args)
+  def initialize(catalog, *args, **kwargs)
+    super(*args, **kwargs)
 
     @catalog = catalog
 

--- a/lib/gel/catalog/legacy_index.rb
+++ b/lib/gel/catalog/legacy_index.rb
@@ -12,7 +12,7 @@ class Gel::Catalog::LegacyIndex
   include Gel::Catalog::Common
   CACHE_TYPE = "quick"
 
-  def initialize(*)
+  def initialize(*args, **kwargs)
     super
 
     @needs_update = true

--- a/lib/gel/resolved_gem_set.rb
+++ b/lib/gel/resolved_gem_set.rb
@@ -3,13 +3,19 @@
 require "set"
 
 class Gel::ResolvedGemSet
-  class ResolvedGem < Struct.new(:type, :body, :name, :version, :platform, :deps)
-    attr_reader :set
+  class ResolvedGem
+    attr_reader :type, :body, :name, :version, :platform, :deps, :set
 
-    def initialize(*args, set:, catalog: nil)
+    def initialize(type, body, name, version, platform, deps, set:, catalog: nil)
       require_relative "catalog"
 
-      super(*args)
+      @type = type
+      @body = body
+      @name = name
+      @version = version
+      @platform = platform
+      @deps = deps
+
       @set = set
       @catalog = catalog
     end


### PR DESCRIPTION
This fixes a number of:
"Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call"
warnings.