### PR TITLE
Add flags for version and help

### DIFF
--- a/lib/gel/command.rb
+++ b/lib/gel/command.rb
@@ -18,6 +18,8 @@ class Gel::Command
       else
         raise Gel::Error::UnknownCommandError.new(command_name: command_name)
       end
+    elsif flag_constant = flags(command_line).first
+      flag_constant.new.run(command_line)
     else
       puts <<~EOF
       Gel doesn't have a default command; please run `gel install`
@@ -68,12 +70,27 @@ class Gel::Command
     end
   end
 
+  def self.flags(arguments)
+    flag_constants = {
+      "h" => Gel::Command::Help,
+      "help" => Gel::Command::Help,
+      "v" => Gel::Command::Version,
+      "version" => Gel::Command::Version,
+    }
+
+    arguments.map { |word|
+      match = word.match(/-+(?<flag>\w+)/)
+      match && flag_constants[match[:flag]]
+    }.compact
+  end
+
   # If set to true, an error raised from #run will pass straight up to
   # ruby instead of being treated as an internal Gel error
   attr_accessor :reraise
 end
 
 require_relative "command/help"
+require_relative "command/version"
 require_relative "command/install"
 require_relative "command/install_gem"
 require_relative "command/env"

--- a/lib/gel/command/version.rb
+++ b/lib/gel/command/version.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class Gel::Command::Version < Gel::Command
+  def run(_command_line)
+    puts "Gel version #{Gel::VERSION}"
+  end
+end

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -30,6 +30,26 @@ class CLITest < Minitest::Test
     Gel::Command.run(%W(help))
   end
 
+  def test_help_flag
+    Gel::Command::Help.expects(:new).returns(mock(run: true))
+
+    Gel::Command.run(%W(--help))
+  end
+
+  def test_version_flag
+    Gel::Command::Version.expects(:new).returns(mock(run: true))
+
+    Gel::Command.run(%W(--version))
+  end
+
+  def test_flag_abriviations
+    Gel::Command::Version.expects(:new).returns(mock(run: true))
+    Gel::Command::Help.expects(:new).returns(mock(run: true))
+
+    Gel::Command.run(%W(-v))
+    Gel::Command.run(%W(-h))
+  end
+
   def test_basic_install
     Gel::Environment.expects(:activate).with(has_entries(install: true, output: $stderr))
 

--- a/test/command/help_test.rb
+++ b/test/command/help_test.rb
@@ -10,4 +10,12 @@ class HelpTest < Minitest::Test
     assert output =~ %r{Usage}
     assert output =~ %r{https://gel.dev}
   end
+
+  def test_help_flag
+    output = capture_stdout { Gel::Command::Help.run(["--help"]) }
+
+    assert output =~ %r{Gel is a modern gem manager}
+    assert output =~ %r{Usage}
+    assert output =~ %r{https://gel.dev}
+  end
 end

--- a/test/command/version_test.rb
+++ b/test/command/version_test.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class HelpTest < Minitest::Test
+  def test_help
+    output = capture_stdout { Gel::Command::Version.run(["--version"]) }
+
+    assert output =~ %r{Gel version}
+  end
+end


### PR DESCRIPTION
I noticed that the man page includes a `--version` flag, but doesn't implement it. This adds that and the `--help` flag with their abbreviations.