### PR TITLE
Automatically update Gemfile.lock when out of date

### DIFF
--- a/lib/gel/environment.rb
+++ b/lib/gel/environment.rb
@@ -361,12 +361,16 @@ class Gel::Environment
       write_lock(output: $stderr, lockfile: lockfile)
     end
 
-    @active_lockfile = true
-    loader = Gel::LockLoader.new(Gel::ResolvedGemSet.load(lockfile), gemfile)
 
-    if lock_outdated?(loaded, loader)
+    resolved_gem_set = Gel::ResolvedGemSet.new(lockfile)
+    Gel::ResolvedGemSet.read_lockfile(lockfile, resolved_gem_set)
+
+    if lock_outdated?(loaded, resolved_gem_set)
       write_lock(output: $stderr, lockfile: lockfile)
     end
+
+    @active_lockfile = true
+    loader = Gel::LockLoader.new(Gel::ResolvedGemSet.load(lockfile), gemfile)
 
     base_store = Gel::Environment.store
     base_store = base_store.inner if base_store.is_a?(Gel::LockedStore)
@@ -374,10 +378,10 @@ class Gel::Environment
     loader.activate(Gel::Environment, base_store, install: install, output: output)
   end
 
-  def self.lock_outdated?(gemfile, lockfile)
+  def self.lock_outdated?(gemfile, resolved_gem_set)
     gemfile_gems = gemfile.gems.map { |gem| gem[0] }
-    lockfile_gems = lockfile.gem_set.dependency_names
-    (lockfile.gem_set.dependency_names & gemfile_gems).size < [gemfile_gems.size, lockfile_gems.size].max
+    lockfile_gems = resolved_gem_set.dependency_names
+    (resolved_gem_set.dependency_names & gemfile_gems).size < [gemfile_gems.size, lockfile_gems.size].max
   end
 
   def self.activate_for_executable(exes, install: false, output: nil)

--- a/lib/gel/environment.rb
+++ b/lib/gel/environment.rb
@@ -364,10 +364,20 @@ class Gel::Environment
     @active_lockfile = true
     loader = Gel::LockLoader.new(Gel::ResolvedGemSet.load(lockfile), gemfile)
 
+    if lock_outdated?(loaded, loader)
+      write_lock(output: $stderr, lockfile: lockfile)
+    end
+
     base_store = Gel::Environment.store
     base_store = base_store.inner if base_store.is_a?(Gel::LockedStore)
 
     loader.activate(Gel::Environment, base_store, install: install, output: output)
+  end
+
+  def self.lock_outdated?(gemfile, lockfile)
+    gemfile_gems = gemfile.gems.map { |gem| gem[0] }
+    lockfile_gems = lockfile.gem_set.dependency_names
+    (lockfile.gem_set.dependency_names & gemfile_gems).size < [gemfile_gems.size, lockfile_gems.size].max
   end
 
   def self.activate_for_executable(exes, install: false, output: nil)

--- a/lib/gel/lock_loader.rb
+++ b/lib/gel/lock_loader.rb
@@ -5,7 +5,7 @@ require_relative "resolved_gem_set"
 require_relative "support/gem_platform"
 
 class Gel::LockLoader
-  attr_reader :gemfile
+  attr_reader :gemfile, :gem_set
 
   def initialize(gem_set, gemfile = nil)
     @gem_set = gem_set

--- a/lib/gel/lock_loader.rb
+++ b/lib/gel/lock_loader.rb
@@ -5,7 +5,7 @@ require_relative "resolved_gem_set"
 require_relative "support/gem_platform"
 
 class Gel::LockLoader
-  attr_reader :gemfile, :gem_set
+  attr_reader :gemfile
 
   def initialize(gem_set, gemfile = nil)
     @gem_set = gem_set

--- a/test/resolve_test.rb
+++ b/test/resolve_test.rb
@@ -843,7 +843,7 @@ INFO
           lockfile: nil,
           catalog_options: { cache: cache_dir },
           **options,
-        )
+        ).dump
 
         assert_match(/\AFetching sources\.\.\.+\nResolving dependencies\.\.\.+\n\z/, output.string)
       end

--- a/test/write_lockfile_test.rb
+++ b/test/write_lockfile_test.rb
@@ -257,6 +257,76 @@ CURRENT_LOCKFILE
     end
   end
 
+  def test_does_write_lockfile_when_gem_version_changes
+    stub_request(:get, "https://index.rubygems.org/versions").
+      to_return(body: <<VERSIONS)
+created_at: 2017-03-27T04:38:13+00:00
+---
+rack 2.0.3 xxx
+
+VERSIONS
+
+    stub_request(:get, "https://index.rubygems.org/info/rack").
+      to_return(body: <<INFO)
+---
+2.0.3 |checksum:zzz
+INFO
+
+    stub_request(:get, "https://rubygems.org/gems/rack-2.0.3.gem").
+      to_return(body: File.open(fixture_file("rack-2.0.3.gem")))
+
+    env = {
+      "GEL_LOCKFILE" => nil
+    }
+    with_env(env: env) do
+      gemfile = File.new("Gemfile", "w+")
+      gemfile.write(<<GEMFILE)
+source "https://rubygems.org"
+
+gem "rack", "2.0.3"
+GEMFILE
+      gemfile.close
+
+      lockfile_contents = <<CURRENT_LOCKFILE
+GEM
+  remote: https://rubygems.org/
+  specs:
+    rack (2.0.2)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  rack
+CURRENT_LOCKFILE
+
+      lockfile = File.new("Gemfile.lock", "w+")
+      lockfile.write(lockfile_contents)
+      lockfile.close
+
+      expected_lockfile_contents = <<EXPECTED_LOCKFILE
+GEM
+  remote: https://rubygems.org/
+  specs:
+    rack (2.0.3)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  rack (= 2.0.3)
+EXPECTED_LOCKFILE
+
+      with_empty_store do |store|
+        subprocess_output(<<-'END', store: store)
+          Gel::Environment.activate(install: true, output: StringIO.new)
+        END
+      end
+
+      assert_equal expected_lockfile_contents, File.read("#{Dir.pwd}/Gemfile.lock")
+    end
+  end
+
   def with_env(env:)
     prev_env = {}
     prev_dir = Dir.pwd

--- a/test/write_lockfile_test.rb
+++ b/test/write_lockfile_test.rb
@@ -1,0 +1,239 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class WriteLockfileTest < Minitest::Test
+  def test_lockfile_written_when_missing
+    stub_request(:get, "https://index.rubygems.org/versions").
+      to_return(body: <<VERSIONS)
+created_at: 2017-03-27T04:38:13+00:00
+---
+rack 2.0.3 xxx
+VERSIONS
+
+    stub_request(:get, "https://index.rubygems.org/info/rack").
+      to_return(body: <<INFO)
+---
+2.0.3 |checksum:zzz
+INFO
+
+
+    stub_request(:get, "https://rubygems.org/gems/rack-2.0.3.gem").
+      to_return(body: File.open(fixture_file("rack-2.0.3.gem")))
+
+    env = {
+      "GEL_LOCKFILE" => nil
+    }
+    with_env(env: env) do
+      gemfile = File.new("Gemfile", "w+")
+      gemfile.write(<<GEMFILE)
+source "https://rubygems.org"
+
+gem "rack"
+GEMFILE
+      gemfile.close
+      with_empty_store do |store|
+        subprocess_output(<<-'END', store: store)
+          Gel::Environment.activate(install: true, output: StringIO.new)
+        END
+      end
+      assert_equal <<LOCKFILE, File.read("#{Dir.pwd}/Gemfile.lock")
+GEM
+  remote: https://rubygems.org/
+  specs:
+    rack (2.0.3)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  rack
+LOCKFILE
+    end
+  end
+
+  def test_lockfile_updated_when_gem_added
+        stub_request(:get, "https://index.rubygems.org/versions").
+      to_return(body: <<VERSIONS)
+created_at: 2017-03-27T04:38:13+00:00
+---
+rack 2.0.3 xxx
+rack-test 0.6.3 xxx
+
+VERSIONS
+
+    stub_request(:get, "https://index.rubygems.org/info/rack").
+      to_return(body: <<INFO)
+---
+2.0.3 |checksum:zzz
+INFO
+
+    stub_request(:get, "https://index.rubygems.org/info/rack-test").
+      to_return(body: <<INFO)
+---
+0.6.3 |checksum:zzz
+INFO
+
+
+    stub_request(:get, "https://rubygems.org/gems/rack-2.0.3.gem").
+      to_return(body: File.open(fixture_file("rack-2.0.3.gem")))
+
+    env = {
+      "GEL_LOCKFILE" => nil
+    }
+    with_env(env: env) do
+      gemfile = File.new("Gemfile", "w+")
+      gemfile.write(<<GEMFILE)
+source "https://rubygems.org"
+
+gem "rack"
+gem "rack-test"
+GEMFILE
+      gemfile.close
+
+      lockfile = File.new("Gemfile.lock", "w+")
+      lockfile.write(<<CURRENT_LOCKFILE)
+GEM
+  remote: https://rubygems.org/
+  specs:
+    rack (2.0.3)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  rack
+CURRENT_LOCKFILE
+      lockfile.close
+
+      with_empty_store do |store|
+        subprocess_output(<<-'END', store: store)
+          Gel::Environment.activate(install: true, output: StringIO.new)
+        END
+      end
+
+      assert_equal <<LOCKFILE, File.read("#{Dir.pwd}/Gemfile.lock")
+GEM
+  remote: https://rubygems.org/
+  specs:
+    rack (2.0.3)
+    rack-test (0.6.3)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  rack
+  rack-test
+LOCKFILE
+    end
+  end
+
+  def test_lockfile_updated_when_gem_removed
+        stub_request(:get, "https://index.rubygems.org/versions").
+      to_return(body: <<VERSIONS)
+created_at: 2017-03-27T04:38:13+00:00
+---
+rack 2.0.3 xxx
+rack-test 0.6.3 xxx
+
+VERSIONS
+
+    stub_request(:get, "https://index.rubygems.org/info/rack").
+      to_return(body: <<INFO)
+---
+2.0.3 |checksum:zzz
+INFO
+
+#     stub_request(:get, "https://index.rubygems.org/info/rack-test").
+#       to_return(body: <<INFO)
+# ---
+# 0.6.3 |checksum:zzz
+# INFO
+
+
+    stub_request(:get, "https://rubygems.org/gems/rack-2.0.3.gem").
+      to_return(body: File.open(fixture_file("rack-2.0.3.gem")))
+
+    env = {
+      "GEL_LOCKFILE" => nil
+    }
+    with_env(env: env) do
+      gemfile = File.new("Gemfile", "w+")
+      gemfile.write(<<GEMFILE)
+source "https://rubygems.org"
+
+gem "rack"
+GEMFILE
+      gemfile.close
+
+      lockfile = File.new("Gemfile.lock", "w+")
+      lockfile.write(<<CURRENT_LOCKFILE)
+GEM
+  remote: https://rubygems.org/
+  specs:
+    rack (2.0.3)
+    rack-test (0.6.3)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  rack
+  rack-test
+CURRENT_LOCKFILE
+      lockfile.close
+
+      with_empty_store do |store|
+        subprocess_output(<<-'END', store: store)
+          Gel::Environment.activate(install: true, output: StringIO.new)
+        END
+      end
+
+      assert_equal <<LOCKFILE, File.read("#{Dir.pwd}/Gemfile.lock")
+GEM
+  remote: https://rubygems.org/
+  specs:
+    rack (2.0.3)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  rack
+LOCKFILE
+    end
+  end
+
+  def with_env(env:)
+    prev_env = {}
+    prev_dir = Dir.pwd
+    prev_gemfile = Gel::Environment.instance_variable_get(:@gemfile)
+    prev_active_lockfile = Gel::Environment.instance_variable_get(:@active_lockfile)
+
+
+    Gel::Environment.instance_variable_set(:@gemfile, nil)
+    Gel::Environment.instance_variable_set(:@active_lockfile, nil)
+
+
+    env.each do |key, val|
+      prev_env[key] = ENV[key]
+      ENV[key] = val
+    end
+
+    Dir.mktmpdir do |project_dir|
+      Dir.chdir project_dir do
+        yield
+      end
+    end
+
+
+  ensure
+    prev_env.each do |key, val|
+      ENV[key] = val
+    end
+
+    Gel::Environment.instance_variable_set(:@gemfile, prev_gemfile)
+    Gel::Environment.instance_variable_set(:@active_lockfile, prev_active_lockfile)
+  end
+end

--- a/test/write_lockfile_test.rb
+++ b/test/write_lockfile_test.rb
@@ -53,7 +53,7 @@ LOCKFILE
   end
 
   def test_lockfile_updated_when_gem_added
-        stub_request(:get, "https://index.rubygems.org/versions").
+    stub_request(:get, "https://index.rubygems.org/versions").
       to_return(body: <<VERSIONS)
 created_at: 2017-03-27T04:38:13+00:00
 ---
@@ -74,6 +74,8 @@ INFO
 0.6.3 |checksum:zzz
 INFO
 
+    stub_request(:get, "https://rubygems.org/gems/rack-test-0.6.3.gem").
+      to_return(body: File.open(fixture_file("rack-test-0.6.3.gem")))
 
     stub_request(:get, "https://rubygems.org/gems/rack-2.0.3.gem").
       to_return(body: File.open(fixture_file("rack-2.0.3.gem")))
@@ -144,13 +146,6 @@ VERSIONS
 ---
 2.0.3 |checksum:zzz
 INFO
-
-#     stub_request(:get, "https://index.rubygems.org/info/rack-test").
-#       to_return(body: <<INFO)
-# ---
-# 0.6.3 |checksum:zzz
-# INFO
-
 
     stub_request(:get, "https://rubygems.org/gems/rack-2.0.3.gem").
       to_return(body: File.open(fixture_file("rack-2.0.3.gem")))


### PR DESCRIPTION
When a gem is added or removed from the Gemfile, the Gemfile.lock now updates automatically.
This does mean that gel will now write the Gemfile.lock more often which means more dependency solving.
This behavior more closely matches bundler and prevents confusion around when your Gemfile and Gemfile.lock might not be in sync.

<details><summary>Current Behavior</summary>
```shell
$ ls
Gemfile
$ cat Gemfile
source 'https://rubygems.org'
gem 'httparty'
$ gel install
Fetching sources...
.
Resolving dependencies...
Writing lockfile to /Users/hparker/code/ruby_home/Gemfile.lock
$ cat Gemfile.lock
GEM
  remote: https://rubygems.org/
  specs:
    httparty (0.18.0)
      mime-types (~> 3.0)
      multi_xml (>= 0.5.2)
    mime-types (3.3.1)
      mime-types-data (~> 3.2015)
    mime-types-data (3.2019.1009)
    multi_xml (0.6.0)

PLATFORMS
  ruby

DEPENDENCIES
  httparty
$ echo "gem 'mail'" >> Gemfile
$ gel install
$ cat Gemfile.lock
GEM
  remote: https://rubygems.org/
  specs:
    httparty (0.18.0)
      mime-types (~> 3.0)
      multi_xml (>= 0.5.2)
    mime-types (3.3.1)
      mime-types-data (~> 3.2015)
    mime-types-data (3.2019.1009)
    multi_xml (0.6.0)

PLATFORMS
  ruby

DEPENDENCIES
  httparty
$ gel update
Fetching sources...
.
Resolving dependencies...
Writing lockfile to /Users/hparker/code/ruby_home/Gemfile.lock
$
cat Gemfile.lock
GEM
  remote: https://rubygems.org/
  specs:
    httparty (0.18.0)
      mime-types (~> 3.0)
      multi_xml (>= 0.5.2)
    mail (2.7.1)
      mini_mime (>= 0.1.1)
    mime-types (3.3.1)
      mime-types-data (~> 3.2015)
    mime-types-data (3.2019.1009)
    mini_mime (1.0.2)
    multi_xml (0.6.0)

PLATFORMS
  ruby

DEPENDENCIES
  httparty
  mail
```
</details>