### PR TITLE
Proposal to stop gel looking for / putting lockfile in strange places.

### DIFF
--- a/lib/gel/environment.rb
+++ b/lib/gel/environment.rb
@@ -104,10 +104,7 @@ class Gel::Environment
   end
 
   def self.lockfile_name(gemfile = self.gemfile&.filename)
-    ENV["GEL_LOCKFILE"] ||
-      (gemfile && File.exist?(gemfile + ".lock") && gemfile + ".lock") ||
-      search_upwards("Gemfile.lock") ||
-      "Gemfile.lock"
+    ENV["GEL_LOCKFILE"] || (gemfile && gemfile + ".lock") || "Gemfile.lock"
   end
 
   def self.with_root_store


### PR DESCRIPTION
By removing the existance-of-lock-file check and the search-upwards check the lockfile
can be requested via `gel lock` and end up in the project root dir.

fix: #104