### PR TITLE
Get in sync with latest JRuby

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -27,5 +27,5 @@ steps:
   - <<: *rake
     name: "JRuby"
     env:
-      RUBY_IMAGE: "jruby:9.2.7.0" # https://github.com/jruby/jruby/issues/5863
+      RUBY_IMAGE: "jruby"
     soft_fail: true

--- a/lib/gel/gemspec_parser.rb
+++ b/lib/gel/gemspec_parser.rb
@@ -66,7 +66,6 @@ class Gel::GemspecParser
                     "RUBYOPT" => "",
                     "GEL_GEMFILE" => "",
                     "GEL_LOCKFILE" => "",
-                    "GEL_DISABLED" => "1", # https://github.com/jruby/jruby/pull/5907
                   },
                   RbConfig.ruby,
                   "-r", File.expand_path("compatibility", __dir__),

--- a/lib/gel/runtime.rb
+++ b/lib/gel/runtime.rb
@@ -22,6 +22,6 @@ store = Gel::MultiStore.new(dir, stores)
 
 Gel::Environment.open(Gel::LockedStore.new(store))
 
-if ENV["GEL_LOCKFILE"] && ENV["GEL_LOCKFILE"] != "" && !ENV["GEL_DISABLED"]
+if ENV["GEL_LOCKFILE"] && ENV["GEL_LOCKFILE"] != ""
   Gel::Environment.activate(output: $stderr)
 end


### PR DESCRIPTION
The conditionvariable bug we were avoiding in CI is fixed, as is the problem with overriding existing environment variables in `spawn`.

So we can return CI to running the latest, and we can drop the ugly `GEL_DISABLED` workaround.

In the long term we should support a wider range of JRuby versions, but for now, I think it's fine to [silently] require a quite recent release.