### PR TITLE
Avoid clone same repo for Git gems

### DIFF
--- a/lib/gel/git_gems_manager.rb
+++ b/lib/gel/git_gems_manager.rb
@@ -1,0 +1,21 @@
+class Gel::GitGemsManager
+  # These gems all live in rails/rails repository.
+  META_GEMS = {
+    "activesupport" => "rails",
+    "actionpack" => "rails",
+    "actionview" => "rails",
+    "activemodel" => "rails",
+    "activerecord" => "rails",
+    "actionmailer" => "rails",
+    "activejob" => "rails",
+    "actioncable" => "rails",
+    "activestorage" => "rails",
+    "actionmailbox" => "rails",
+    "actiontext" => "rails",
+    "railties" => "rails",
+  }
+
+  def self.lookup(name)
+    META_GEMS.fetch(name) { name }
+  end
+end


### PR DESCRIPTION
When a Gemfile installs rails master, it clones rails for 12 times. By storing Rails‘s subgems in the pending queue under the same name "rails". We can avoid clone rails gems multiple times.

Following is the shape of `@pending` in `Gel::Installer`:

<details>
<summary>Tested Gemfile</summary>

```ruby
source "https://rubygems.org"

ruby "2.7.0"

gem "rails", git: "https://github.com/rails/rails.git"
gem 'bootsnap', require: false
gem "sprockets", git: "https://github.com/rails/sprockets.git"
gem "sprockets-rails", git: "https://github.com/rails/sprockets-rails.git"
gem "pg", "~> 1.2"
gem "slim-rails"
gem "sass-rails", "~> 6.0"
gem "uglifier", ">= 1.3.0"
gem "turbolinks", "~> 5"
gem "lograge"
gem "html-pipeline"
gem "commonmarker"
gem "sanitize"
gem "twemoji"
gem "rouge"
gem "secure_headers"
gem "title", git: "https://github.com/calebthompson/title.git"
gem "rack-rewrite"
gem "hiredis"
gem "redis", require: ["redis", "redis/connection/hiredis"]
gem "gemoji"
gem "nokogiri", ">= 1.7.1"
gem "attr_extras"
gem "rack-timeout", require: "rack/timeout/base"
gem "mail", git: "https://github.com/juanitofatas/mail.git", branch: "pr-1343-ragel-bitmap"
gem "barnes"
gem "thor", ">= 1.0.0"
gem "coffee-rails" # because rails-ujs is written in coffee script.
gem "i18n"
gem "json", ">= 2.3.0"
gem "puma"
gem "puma_worker_killer"

group :production do
  gem "rails_12factor"
end

group :development, :test do
  gem "dotenv-rails", git: "https://github.com/juanitofatas/dotenv.git", branch: "support-rails-61"
  gem "pry-rails"
  gem "rspec-rails"
  gem "listen", "~> 3.2.1"
end

group :development do
  gem "rack-mini-profiler"
  gem "octokit"
  gem "spring"
  gem "spring-watcher-listen", "~> 2.0.0"
  # gem "derailed_benchmarks"
  # gem "derailed"
  gem "memory_profiler"
  gem "httpx"
end

group :test do
  gem "database_rewinder", git: "https://github.com/juanitofatas/database_rewinder.git", branch: "rails62/db-config"
  gem "factory_bot_rails"
  gem "shoulda-matchers"
  gem "webmock"
  gem "launchy"
  gem "capybara"
  gem "webdrivers"
end
```
</details>

#### Before: gel install 441s

```
{}
{"title"=>1}
{"title"=>1, "database_rewinder"=>1}
{"title"=>1, "database_rewinder"=>1, "dotenv"=>1}
{"title"=>1, "database_rewinder"=>1, "dotenv"=>1, "dotenv-rails"=>1}
{"title"=>1, "database_rewinder"=>1, "dotenv"=>1, "dotenv-rails"=>1, "mail"=>1}
{"title"=>1, "database_rewinder"=>1, "dotenv"=>1, "dotenv-rails"=>1, "mail"=>1, "actioncable"=>1}
{"title"=>1, "database_rewinder"=>1, "dotenv"=>1, "dotenv-rails"=>1, "mail"=>1, "actioncable"=>1, "actionmailbox"=>1}
{"title"=>1, "database_rewinder"=>1, "dotenv"=>1, "dotenv-rails"=>1, "mail"=>1, "actioncable"=>1, "actionmailbox"=>1, "actionmailer"=>1}
{"title"=>1, "database_rewinder"=>1, "dotenv"=>1, "dotenv-rails"=>1, "mail"=>1, "actioncable"=>1, "actionmailbox"=>1, "actionmailer"=>1, "actionpack"=>1}
{"title"=>1, "database_rewinder"=>1, "dotenv"=>1, "dotenv-rails"=>1, "mail"=>1, "actioncable"=>1, "actionmailbox"=>1, "actionmailer"=>1, "actionpack"=>1, "actiontext"=>1}
{"title"=>1, "database_rewinder"=>1, "dotenv"=>1, "dotenv-rails"=>1, "mail"=>1, "actioncable"=>1, "actionmailbox"=>1, "actionmailer"=>1, "actionpack"=>1, "actiontext"=>1, "actionview"=>1}
{"title"=>1, "database_rewinder"=>1, "dotenv"=>1, "dotenv-rails"=>1, "mail"=>1, "actioncable"=>1, "actionmailbox"=>1, "actionmailer"=>1, "actionpack"=>1, "actiontext"=>1, "actionview"=>1, "activejob"=>1}
{"title"=>1, "database_rewinder"=>1, "dotenv"=>1, "dotenv-rails"=>1, "mail"=>1, "actioncable"=>1, "actionmailbox"=>1, "actionmailer"=>1, "actionpack"=>1, "actiontext"=>1, "actionview"=>1, "activejob"=>1, "activemodel"=>1}
{"title"=>1, "database_rewinder"=>1, "dotenv"=>1, "dotenv-rails"=>1, "mail"=>1, "actioncable"=>1, "actionmailbox"=>1, "actionmailer"=>1, "actionpack"=>1, "actiontext"=>1, "actionview"=>1, "activejob"=>1, "activemodel"=>1, "activerecord"=>1}
{"title"=>1, "database_rewinder"=>1, "dotenv"=>1, "dotenv-rails"=>1, "mail"=>1, "actioncable"=>1, "actionmailbox"=>1, "actionmailer"=>1, "actionpack"=>1, "actiontext"=>1, "actionview"=>1, "activejob"=>1, "activemodel"=>1, "activerecord"=>1, "activestorage"=>1}
{"title"=>1, "database_rewinder"=>1, "dotenv"=>1, "dotenv-rails"=>1, "mail"=>1, "actioncable"=>1, "actionmailbox"=>1, "actionmailer"=>1, "actionpack"=>1, "actiontext"=>1, "actionview"=>1, "activejob"=>1, "activemodel"=>1, "activerecord"=>1, "activestorage"=>1, "activesupport"=>1}
{"title"=>1, "database_rewinder"=>1, "dotenv"=>1, "dotenv-rails"=>1, "mail"=>1, "actioncable"=>1, "actionmailbox"=>1, "actionmailer"=>1, "actionpack"=>1, "actiontext"=>1, "actionview"=>1, "activejob"=>1, "activemodel"=>1, "activerecord"=>1, "activestorage"=>1, "activesupport"=>1, "rails"=>1}
{"title"=>1, "database_rewinder"=>1, "dotenv"=>1, "dotenv-rails"=>1, "mail"=>1, "actioncable"=>1, "actionmailbox"=>1, "actionmailer"=>1, "actionpack"=>1, "actiontext"=>1, "actionview"=>1, "activejob"=>1, "activemodel"=>1, "activerecord"=>1, "activestorage"=>1, "activesupport"=>1, "rails"=>1, "railties"=>1}
{"title"=>1, "database_rewinder"=>1, "dotenv"=>1, "dotenv-rails"=>1, "mail"=>1, "actioncable"=>1, "actionmailbox"=>1, "actionmailer"=>1, "actionpack"=>1, "actiontext"=>1, "actionview"=>1, "activejob"=>1, "activemodel"=>1, "activerecord"=>1, "activestorage"=>1, "activesupport"=>1, "rails"=>1, "railties"=>1, "sprockets-rails"=>1}
```

#### After: gel install 354s

```
{}
{"title"=>1}
{"title"=>1, "database_rewinder"=>1}
{"title"=>1, "database_rewinder"=>1, "dotenv"=>1}
{"title"=>1, "database_rewinder"=>1, "dotenv"=>1, "dotenv-rails"=>1}
{"title"=>1, "database_rewinder"=>1, "dotenv"=>1, "dotenv-rails"=>1, "mail"=>1}
{"title"=>1, "database_rewinder"=>1, "dotenv"=>1, "dotenv-rails"=>1, "mail"=>1, "rails"=>1}
{"title"=>1, "database_rewinder"=>1, "dotenv"=>1, "dotenv-rails"=>1, "mail"=>1, "rails"=>1}
{"title"=>1, "database_rewinder"=>1, "dotenv"=>1, "dotenv-rails"=>1, "mail"=>1, "rails"=>1}
{"title"=>1, "database_rewinder"=>1, "dotenv"=>1, "dotenv-rails"=>1, "mail"=>1, "rails"=>1}
{"title"=>1, "database_rewinder"=>1, "dotenv"=>1, "dotenv-rails"=>1, "mail"=>1, "rails"=>1}
{"title"=>1, "database_rewinder"=>1, "dotenv"=>1, "dotenv-rails"=>1, "mail"=>1, "rails"=>1}
{"title"=>1, "database_rewinder"=>1, "dotenv"=>1, "dotenv-rails"=>1, "mail"=>1, "rails"=>1}
{"title"=>1, "database_rewinder"=>1, "dotenv"=>1, "dotenv-rails"=>1, "mail"=>1, "rails"=>1}
{"title"=>1, "database_rewinder"=>1, "dotenv"=>1, "dotenv-rails"=>1, "mail"=>1, "rails"=>1}
{"title"=>1, "database_rewinder"=>1, "dotenv"=>1, "dotenv-rails"=>1, "mail"=>1, "rails"=>1}
{"title"=>1, "database_rewinder"=>1, "dotenv"=>1, "dotenv-rails"=>1, "mail"=>1, "rails"=>1}
{"title"=>1, "database_rewinder"=>1, "dotenv"=>1, "dotenv-rails"=>1, "mail"=>1, "rails"=>1}
{"title"=>1, "database_rewinder"=>1, "dotenv"=>1, "dotenv-rails"=>1, "mail"=>1, "rails"=>1}
{"title"=>1, "database_rewinder"=>1, "dotenv"=>1, "dotenv-rails"=>1, "mail"=>1, "rails"=>1, "sprockets-rails"=>1}
```
