### PR TITLE
Use the resolved gem's #catalog, not #body

### DIFF
--- a/lib/gel/git_catalog.rb
+++ b/lib/gel/git_catalog.rb
@@ -5,11 +5,12 @@ require_relative "path_catalog"
 class Gel::GitCatalog
   attr_reader :git_depot, :remote, :ref_type, :ref
 
-  def initialize(git_depot, remote, ref_type, ref)
+  def initialize(git_depot, remote, ref_type, ref, revision = nil)
     @git_depot = git_depot
     @remote = remote
     @ref_type = ref_type
     @ref = ref
+    @revision = revision
 
     @monitor = Monitor.new
     @result = nil
@@ -21,7 +22,7 @@ class Gel::GitCatalog
   end
 
   def revision
-    checkout_result[0]
+    @revision || checkout_result[0]
   end
 
   def gem_info(name)
@@ -34,5 +35,9 @@ class Gel::GitCatalog
 
   def prepare
     checkout_result
+  end
+
+  def path
+    git_depot.git_path(remote, revision)
   end
 end

--- a/test/write_lockfile_test.rb
+++ b/test/write_lockfile_test.rb
@@ -4,22 +4,13 @@ require "test_helper"
 
 class WriteLockfileTest < Minitest::Test
   def test_lockfile_written_when_missing
-    stub_request(:get, "https://index.rubygems.org/versions").
-      to_return(body: <<VERSIONS)
-created_at: 2017-03-27T04:38:13+00:00
----
-rack 2.0.3 xxx
-VERSIONS
+    stub_gem_mimer(source: "https://index.rubygems.org")
 
-    stub_request(:get, "https://index.rubygems.org/info/rack").
-      to_return(body: <<INFO)
----
-2.0.3 |checksum:zzz
-INFO
+    stub_request(:get, "https://rubygems.org/gems/rack-2.0.6.gem").
+      to_return(body: File.open(fixture_file("rack-2.0.6.gem")))
 
-
-    stub_request(:get, "https://rubygems.org/gems/rack-2.0.3.gem").
-      to_return(body: File.open(fixture_file("rack-2.0.3.gem")))
+    stub_request(:get, "https://rubygems.org/gems/pub_grub-0.5.0.gem").
+      to_return(body: File.open(fixture_file("pub_grub-0.5.0.gem")))
 
     env = {
       "GEL_LOCKFILE" => nil
@@ -33,15 +24,22 @@ gem "rack"
 GEMFILE
       gemfile.close
       with_empty_store do |store|
-        subprocess_output(<<-'END', store: store)
-          Gel::Environment.activate(install: true, output: StringIO.new)
+        output = subprocess_output(<<-'END', store: store)
+          Gel::Environment.with_store(store) do
+            Gel::Environment.activate(install: true, output: StringIO.new)
+            Gel::Environment.gem "rack"
+
+            puts $:.grep(/\brack/).join(":")
+          end
         END
+
+        assert_equal "#{store.root}/gems/rack-2.0.6/lib", output.shift
       end
       assert_equal <<LOCKFILE, File.read("#{Dir.pwd}/Gemfile.lock")
 GEM
   remote: https://rubygems.org/
   specs:
-    rack (2.0.3)
+    rack (2.0.6)
 
 PLATFORMS
   ruby
@@ -328,10 +326,28 @@ EXPECTED_LOCKFILE
   end
 
   def test_correctly_handles_bang_gemfile
+    stub_gem_mimer(source: "https://index.rubygems.org")
+
+    stub_request(:get, "https://rubygems.org/gems/pub_grub-0.5.0.gem").
+      to_return(body: File.open(fixture_file("pub_grub-0.5.0.gem")))
+
+    stub_request(:get, "https://rubygems.org/gems/rack-2.0.6.gem").
+      to_return(body: File.open(fixture_file("rack-2.0.6.gem")))
+
     env = {
       "GEL_LOCKFILE" => nil
     }
     with_env(env: env) do
+      Dir.mkdir "my-local-gem"
+      IO.write("my-local-gem/my-local-gem.gemspec", <<GEMSPEC)
+Gem::Specification.new do |spec|
+  spec.name = "my-local-gem"
+  spec.version = "867.5309"
+
+  spec.add_runtime_dependency "rack"
+end
+GEMSPEC
+
       gemfile = File.new("Gemfile", "w+")
       gemfile.write(<<GEMFILE)
 source "https://rubygems.org"
@@ -340,34 +356,57 @@ gem "my-local-gem", path: './my-local-gem'
 GEMFILE
       gemfile.close
 
-      lockfile_contents = <<CURRENT_LOCKFILE
+      lockfile_contents = <<LOCKFILE
 PATH
   remote: ./my-local-gem
   specs:
-    my-local-gem (0.1.0)
-
+    my-local-gem (867.5309)
+      rack
 
 GEM
   remote: https://rubygems.org/
   specs:
+    rack (2.0.6)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   my-local-gem!
-CURRENT_LOCKFILE
+LOCKFILE
 
-      lockfile = File.new("Gemfile.lock", "w+")
-      lockfile.write(lockfile_contents)
-      lockfile.close
-
+      # Resolve from scratch, generating the lockfile
       with_empty_store do |store|
-        subprocess_output(<<-'END', store: store)
-          Gel::Environment.activate(install: true, output: StringIO.new)
+        output = subprocess_output(<<-'END', store: store)
+          Gel::Environment.with_store(store) do
+            Gel::Environment.activate(install: true, output: StringIO.new)
+            Gel::Environment.gem "my-local-gem"
+
+            puts $:.grep(/\bmy-local-gem/).join(":")
+          end
         END
+
+        assert_equal "#{Dir.pwd}/my-local-gem/lib", output.shift
       end
 
+      # Check we ended up with the lockfile we expected
+      assert_equal lockfile_contents, File.read("#{Dir.pwd}/Gemfile.lock")
+
+      # Now do a fresh run, using that as an "existing" lockfile
+      with_empty_store do |store|
+        output = subprocess_output(<<-'END', store: store)
+          Gel::Environment.with_store(store) do
+            Gel::Environment.activate(install: true, output: StringIO.new)
+            Gel::Environment.gem "my-local-gem"
+
+            puts $:.grep(/\bmy-local-gem/).join(":")
+          end
+        END
+
+        assert_equal "#{Dir.pwd}/my-local-gem/lib", output.shift
+      end
+
+      # Check it didn't change
       assert_equal lockfile_contents, File.read("#{Dir.pwd}/Gemfile.lock")
     end
   end


### PR DESCRIPTION
body isn't there for a freshly-resolved entry; instead of back-filling it, let's just use real objects more often. Storing the raw body was always a cop-out anyway.

This fixes #112, a bug I introduced in 70e57c3badc7f8837a979cf952687fa401bcc608 -- though it was actually a latent issue / oversight in #57.