### PR TITLE
Fix non-matching filter

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -29,6 +29,7 @@ FIXTURE_GEMS = [
   ["rainbow", "2.2.2"],
   ["rake", "12.3.2"],
   ["pub_grub", "0.5.0"],
+  ["ruby_parser", "3.8.2"]
 ]
 
 # These gems specify the subset of the entire gemspace that is simulated

--- a/lib/gel/package/installer.rb
+++ b/lib/gel/package/installer.rb
@@ -231,7 +231,8 @@ class Gel::Package::Installer
         is_first = true
         spec.require_paths.each do |reqp|
           location = is_first ? spec.version : [spec.version, reqp]
-          store.add_lib(spec.name, location, @files[reqp].map { |s| s.sub(loadable_file_types_re, "") })
+          files = @files[reqp].map { |s| s.sub(loadable_file_types_re, "") if s.match(loadable_file_types_re) }.compact
+          store.add_lib(spec.name, location, files)
           is_first = false
         end
 

--- a/test/install_test.rb
+++ b/test/install_test.rb
@@ -152,4 +152,33 @@ class InstallTest < Minitest::Test
       }, store.gem("rainbow", "2.2.2").info)
     end
   end
+
+  def test_installing_a_problematic_gem
+    Dir.mktmpdir do |dir|
+      store = Gel::Store.new(dir)
+
+      result = Gel::Package::Installer.new(store)
+      g = Gel::Package.extract(fixture_file("ruby_parser-3.8.2.gem"), result)
+      g.compile
+      g.install
+
+      assert File.exist?("#{dir}/gems/ruby_parser-3.8.2/README.txt")
+
+      entries = []
+      store.each do |gem|
+        entries << [gem.name, gem.version]
+      end
+
+      assert_equal [
+        ["ruby_parser", "3.8.2"]
+      ], entries.sort
+
+      assert_equal({
+        bindir: "bin",
+        executables: ["ruby_parse", "ruby_parse_extract_error"],
+        require_paths: ["lib"],
+        dependencies: {"sexp_processor"=>[["~>", "4.1"]]},
+      }, store.gem("ruby_parser", "3.8.2").info)
+    end
+  end
 end

--- a/test/write_lockfile_test.rb
+++ b/test/write_lockfile_test.rb
@@ -413,14 +413,13 @@ LOCKFILE
 
   def with_env(env:)
     prev_env = {}
-    prev_dir = Dir.pwd
+
     prev_gemfile = Gel::Environment.instance_variable_get(:@gemfile)
     prev_active_lockfile = Gel::Environment.instance_variable_get(:@active_lockfile)
 
 
     Gel::Environment.instance_variable_set(:@gemfile, nil)
     Gel::Environment.instance_variable_set(:@active_lockfile, nil)
-
 
     env.each do |key, val|
       prev_env[key] = ENV[key]
@@ -432,7 +431,6 @@ LOCKFILE
         yield
       end
     end
-
 
   ensure
     prev_env.each do |key, val|


### PR DESCRIPTION
Hi, thanks for your fantastic gem!

We would like to fix behavior for a non-matching filter which currently blocks us from using your gem:
* if the package contains a file with an ending not in %w[.rb #{DLEXT} #{DLEXT2}], i.e. somefile.kex - we don't want to track it 

What we changed:
* Deleted unused variable
* Added problematic package for testing purposes
* Added test for this case
* Removed unused variable



