### PR TITLE
Introduce GEL_AUTH for gem server credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,10 @@ Use `gel install`, `gel lock`, `gel update`, and `gel exec` as you would the equ
 * `GEL_CACHE`
   The path to the gel version information cache
 
+* `GEL_AUTH`
+  Gem server credentials as a space-separated list of URIs, e.g.:
+  "http://user:pass@ruby.example.com/ http://user2:pass2@gems.example.org/"
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `bin/rake test` to run the tests.

--- a/lib/gel/config.rb
+++ b/lib/gel/config.rb
@@ -1,8 +1,26 @@
 # frozen_string_literal: true
 
+##
+# Reads an optional config file ~/.config/gel/config.
+#
+# Config file format:
+#
+#     # comment:
+#     context-name: # where context-name in [build]
+#       key: val
+#
+#     key: val
+#
+# Example:
+#
+#     build:
+#       nokogiri: --libdir=blah
+#
+#     rails-assets.org: username:password
+
 class Gel::Config
-  def initialize
-    @root = File.expand_path("~/.config/gel")
+  def initialize(root_path = "~/.config/gel")
+    @root = File.expand_path(root_path)
     @path = File.join(@root, "config")
     @config = nil
   end
@@ -12,10 +30,6 @@ class Gel::Config
   end
 
   def [](group = nil, key)
-    if group.nil?
-      group, key = key.split(".", 2)
-    end
-
     (group ? (config[group.to_s] || {}) : config)[key.to_s]
   end
 

--- a/lib/gel/config.rb
+++ b/lib/gel/config.rb
@@ -1,7 +1,12 @@
 # frozen_string_literal: true
 
 ##
-# Reads an optional config file ~/.config/gel/config.
+# Reads an optional config file ~/.config/gel/config and injects
+# authorization info from the environment $GEL_AUTH.
+#
+# Environment format:
+#
+#     GEL_AUTH="https://user@pass:host1/ https://user@pass:host2/"
 #
 # Config file format:
 #
@@ -17,6 +22,10 @@
 #       nokogiri: --libdir=blah
 #
 #     rails-assets.org: username:password
+#
+#     ---
+#
+#     GEL_AUTH="https://user@pass:private-gem-server.local"
 
 class Gel::Config
   def initialize(root_path = "~/.config/gel")
@@ -64,6 +73,15 @@ class Gel::Config
         end
       end
     end
+
+    # GEL_AUTH = "http://username:password@host http://username:password@host"
+    if auths = ENV["GEL_AUTH"] then
+      auths.split.each do |auth|
+        auth = URI(auth)
+        result[auth.host] = auth.userinfo
+      end
+    end
+
     result
   end
 

--- a/test/config_test.rb
+++ b/test/config_test.rb
@@ -5,6 +5,8 @@ require "tmpdir"
 
 class ConfigTest < Minitest::Test
   def test_reading_configuration
+    ENV["GEL_AUTH"] = "http://user:pass@ruby.example.com http://user2:pass2@gems.example.org"
+
     dir = Dir.mktmpdir
     File.write("#{dir}/config", <<-CONFIG)
 build:
@@ -20,5 +22,9 @@ ruby-gems.example.com: username:password
     assert_equal "--libdir=foo", config[:build, "nokogiri"]
     assert_equal "--libdir=bar", config[:build, "mysql2"]
     assert_equal "username:password", config["ruby-gems.example.com"]
+    assert_equal "user:pass", config["ruby.example.com"]
+    assert_equal "user2:pass2", config["gems.example.org"]
+  ensure
+    ENV.delete("GEL_AUTH")
   end
 end

--- a/test/config_test.rb
+++ b/test/config_test.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "tmpdir"
+
+class ConfigTest < Minitest::Test
+  def test_reading_configuration
+    dir = Dir.mktmpdir
+    File.write("#{dir}/config", <<-CONFIG)
+build:
+  nokogiri: --libdir=foo
+  mysql2: --libdir=bar
+
+# Gem server credentials
+ruby-gems.example.com: username:password
+    CONFIG
+
+    config = Gel::Config.new(dir)
+
+    assert_equal "--libdir=foo", config[:build, "nokogiri"]
+    assert_equal "--libdir=bar", config[:build, "mysql2"]
+    assert_equal "username:password", config["ruby-gems.example.com"]
+  end
+end


### PR DESCRIPTION
Sometimes, you don't want to store credentials in the global configuration file (~/.config/gel/config).

If you prefer (or need) to provide gem server credentials via an environment variable, set `GEL_AUTH` to a space-separated string of URIs each containing scheme, userinfo and host (and port, if necessary).
