### PR TITLE
Lazily require "digest"

### DIFF
--- a/lib/gel/catalog.rb
+++ b/lib/gel/catalog.rb
@@ -3,7 +3,6 @@
 require "fileutils"
 require "net/http"
 require "uri"
-require "digest"
 
 require_relative "httpool"
 require_relative "support/gem_platform"
@@ -117,6 +116,7 @@ class Gel::Catalog
   end
 
   def uri_identifier
+    require "digest"
     @uri.host + "-" + Digest(:SHA256).hexdigest(@uri.to_s)[0..10]
   end
 

--- a/lib/gel/support/tar/tar_writer.rb
+++ b/lib/gel/support/tar/tar_writer.rb
@@ -5,8 +5,6 @@
 # Redistributed under the terms of the MIT license.
 #++
 
-require 'digest'
-
 ##
 # Allows writing of tar files
 
@@ -175,6 +173,7 @@ class Gel::Support::Tar::TarWriter
   # Returns the digest.
 
   def add_file_signed name, mode, signer
+    require 'digest'
     digest_algorithms = [
       signer.digest_algorithm,
       Digest::SHA512,


### PR DESCRIPTION
If an application has "digest" as a dependency in its Gemfile, using gel
will show warnings because the built-in Digest will be required and then
the Gemfile Digest will get required.

To reproduce, make a Gemfile like this:

```
source "https://rubygems.org"

gem "digest"
```

Then:

```
$ gel install
$ gel exec ruby -e'p :hi'
```

I expect no warnings, but instead I see these warnings:

```
/Users/aaron/.local/gel/3.2.0+0/gems/digest-3.1.0/lib/digest/version.rb:4: warning: already initialized constant Digest::VERSION
/Users/aaron/.rubies/arm64/ruby-trunk/lib/ruby/3.2.0+0/digest/version.rb:4: warning: previous definition of VERSION was here
/Users/aaron/.local/gel/3.2.0+0/gems/digest-3.1.0/lib/digest.rb:20: warning: already initialized constant Digest::REQUIRE_MUTEX
/Users/aaron/.rubies/arm64/ruby-trunk/lib/ruby/3.2.0+0/digest.rb:20: warning: previous definition of REQUIRE_MUTEX was here
```

After this commit there are no warnings