### PR TITLE
Stick the gel command in the enviornment

### DIFF
--- a/exe/gel
+++ b/exe/gel
@@ -1,6 +1,7 @@
 #!/usr/bin/env ruby --disable=gems
 # frozen_string_literal: true
 
+ENV["GEL_PROGRAM_NAME"] = $PROGRAM_NAME
 if defined?(::Gem) && !defined?(::Gel)
   exec ::Gem.ruby,
     "-I", File.expand_path("../lib/gel/compatibility", __dir__),


### PR DESCRIPTION
I am trying to install Rails using Gel only.  But the Rails installation
scripts have a hard dependency on Bundler
[here](https://github.com/rails/rails/blob/df1e1bc35c6210ecb39532a06823a6cf4f07bcd8/railties/lib/rails/generators/app_base.rb#L392-L397).

To fix this, I want to add necessary features so that Gel can replace
this code.  The first issue I want to tackle is [this
line](https://github.com/rails/rails/blob/df1e1bc35c6210ecb39532a06823a6cf4f07bcd8/railties/lib/rails/generators/app_base.rb#L392)
that tries to get the Bundler executable.  I don't use Gel from
RubyGems, so it doesn't really make sense to ask `Gem` what the path is
for the Gel executable.  To get around this issue, I would like to stick
the Gel program name in the environment as `GEL_PROGRAM_NAME`.  Then
when I do:

```
$ gel exec rails new ~/git/blah
```

Rails will know that it's being executed with Gel, and it will also know
where to find the Gel binfile so that the install process can `gel
install` on the newly created Rails app.