### PR TITLE
Set BUNDLE_BIN_PATH during exec

### DIFF
--- a/lib/gel/command/exec.rb
+++ b/lib/gel/command/exec.rb
@@ -17,6 +17,7 @@ class Gel::Command::Exec < Gel::Command
     end
 
     ENV["RUBYLIB"] = Gel::Environment.modified_rubylib
+    ENV["BUNDLE_BIN_PATH"] = File.expand_path("../../../exe/gel", __dir__)
 
     if execute_inline?(expanded_command)
       if command_source == :path || command_source == :original

--- a/lib/gel/gemspec_parser.rb
+++ b/lib/gel/gemspec_parser.rb
@@ -79,6 +79,7 @@ class Gel::GemspecParser
                     "GEL_DEBUG" => nil,
                     "GEL_GEMFILE" => "",
                     "GEL_LOCKFILE" => "",
+                    "BUNDLE_BIN_PATH" => nil,
                   },
                   RbConfig.ruby,
                   "-r", File.expand_path("compatibility", __dir__),

--- a/lib/gel/package/installer.rb
+++ b/lib/gel/package/installer.rb
@@ -132,6 +132,7 @@ class Gel::Package::Installer
         "GEL_STORE" => File.expand_path(@root_store.root),
         "GEL_GEMFILE" => gemfile,
         "GEL_LOCKFILE" => lockfile,
+        "BUNDLE_BIN_PATH" => File.expand_path("../../../exe/gel", __dir__),
       }
     end
 


### PR DESCRIPTION
This is a PoLS trade-off: our command is obviously less featureful than 'bundle', but if you're running inside a Gel context, I think you still have a better chance of success from 'gel' than from 'bundle'.

I've generally tried to avoid touching explicitly bundle-y env vars, but this seems like a fair exception, and should be particularly useful for applications that wish to work with both systems: switching from `system("bundle")` to `system(ENV.fetch("BUNDLE_BIN_PATH", "bundle"))` is a small upgrade even in a Bundler context, while also adding Gel support without forcing widespread "if gel else bundler" conditions.

Fixes #124