### PR TITLE
Respect explicit `source:` option on gem entries

### DIFF
--- a/lib/gel/catalog.rb
+++ b/lib/gel/catalog.rb
@@ -86,6 +86,10 @@ class Gel::Catalog
     @uri.to_s
   end
 
+  def match?(uri)
+    @uri == normalize_uri(uri)
+  end
+
   private
 
   def normalize_uri(uri)

--- a/lib/gel/environment.rb
+++ b/lib/gel/environment.rb
@@ -165,9 +165,14 @@ class Gel::Environment
     require_relative "catalog"
     all_sources = (gemfile.sources | gemfile.gems.flat_map { |_, _, o| o[:source] }).compact
     local_source = all_sources.delete(:local)
-    server_gems = gemfile.gems.select { |_, _, o| !o[:path] && !o[:git] }.map(&:first)
+    server_gems = gemfile.gems.select { |_, _, o| !o[:path] && !o[:git] }
     catalog_pool = Gel::WorkPool.new(8, name: "gel-catalog")
-    server_catalogs = all_sources.map { |s| Gel::Catalog.new(s, initial_gems: server_gems, work_pool: catalog_pool, **catalog_options) }
+    server_catalogs = all_sources.map do |s|
+      source_gems = server_gems.
+        select { |_, _, o| Array(o[:source]).include?(s) || o[:source].nil? }.
+        map(&:first)
+      Gel::Catalog.new(s, initial_gems: source_gems, work_pool: catalog_pool, **catalog_options)
+    end
 
     require_relative "store_catalog"
     store = store.inner if store.is_a?(Gel::LockedStore)
@@ -239,7 +244,7 @@ class Gel::Environment
     end
 
     require_relative "catalog_set"
-    catalog_set = Gel::CatalogSet.new(catalogs)
+    catalog_set = Gel::CatalogSet.new(catalogs, gemfile)
 
     if solve
       require_relative "pub_grub/solver"


### PR DESCRIPTION
Previously we were collecting them as valid sources in general, but were not enforcing that those particular gems may _only_ come from the stated catalog.

This particular behaviour was an oversight, but more generally, now that newer Bundler is comfortable with multiple separate `GEM` blocks for multiple catalog sources, we should probably also move that direction. My memory claims I got part way down that path earlier, before deciding we had to follow Bundler's squish-everything-together precedent... but I don't recall whether that involved actual recoverable code, or just some conceptual choices during implementation.