### PR TITLE
Bump pub_grub to include package_depth removal

### DIFF
--- a/lib/gel/pub_grub/solver.rb
+++ b/lib/gel/pub_grub/solver.rb
@@ -18,13 +18,17 @@ class Gel::PubGrub::Solver < Gel::Vendor::PubGrub::VersionSolver
   def next_package_to_try
     self.solution.unsatisfied.min_by do |term|
       package = term.package
-      versions = self.source.versions_for(package, term.constraint.range)
+      range = term.constraint.range
+      matching_versions = source.versions_for(package, range)
+      higher_versions = source.versions_for(package, range.upper_invert)
+
+      matching_priority = matching_versions.count <= 1 ? 0 : 1
 
       if @strategy
-        @strategy.package_priority(package, versions) + @package_depth[package]
+        [@strategy.package_priority(package, matching_versions), matching_priority, higher_versions.count]
       else
-        @package_depth[package]
-      end * 1000 + versions.count
+        [matching_priority, higher_versions.count]
+      end
     end.package
   end
 

--- a/tasks/vendor.rake
+++ b/tasks/vendor.rake
@@ -31,8 +31,8 @@ Automatiek::RakeTask.new("pstore") do |lib|
 end
 
 Automatiek::RakeTask.new("pub_grub") do |lib|
-  lib.version = "range-eql-union"
-  lib.download = { :github => "https://github.com/matthewd/pub_grub" }
+  lib.version = "e5c69d251b3d55791b83d131ddd2b587a282778a"
+  lib.download = { :github => "https://github.com/jhawthorn/pub_grub" }
   lib.namespace = "PubGrub"
   lib.prefix = "Gel::Vendor"
   lib.vendor_lib = "vendor/pub_grub"

--- a/vendor/pub_grub/lib/pub_grub/basic_package_source.rb
+++ b/vendor/pub_grub/lib/pub_grub/basic_package_source.rb
@@ -1,5 +1,5 @@
-require_relative '../pub_grub/version_constraint'
-require_relative '../pub_grub/incompatibility'
+require_relative 'version_constraint'
+require_relative 'incompatibility'
 
 module Gel::Vendor::PubGrub
   # Types:

--- a/vendor/pub_grub/lib/pub_grub/partial_solution.rb
+++ b/vendor/pub_grub/lib/pub_grub/partial_solution.rb
@@ -1,4 +1,4 @@
-require_relative '../pub_grub/assignment'
+require_relative 'assignment'
 
 module Gel::Vendor::PubGrub
   class PartialSolution

--- a/vendor/pub_grub/lib/pub_grub/solve_failure.rb
+++ b/vendor/pub_grub/lib/pub_grub/solve_failure.rb
@@ -1,4 +1,4 @@
-require_relative '../pub_grub/failure_writer'
+require_relative 'failure_writer'
 
 module Gel::Vendor::PubGrub
   class SolveFailure < StandardError

--- a/vendor/pub_grub/lib/pub_grub/static_package_source.rb
+++ b/vendor/pub_grub/lib/pub_grub/static_package_source.rb
@@ -1,7 +1,7 @@
-require_relative '../pub_grub/package'
-require_relative '../pub_grub/version_constraint'
-require_relative '../pub_grub/incompatibility'
-require_relative '../pub_grub/basic_package_source'
+require_relative 'package'
+require_relative 'version_constraint'
+require_relative 'incompatibility'
+require_relative 'basic_package_source'
 
 module Gel::Vendor::PubGrub
   class StaticPackageSource < BasicPackageSource

--- a/vendor/pub_grub/lib/pub_grub/version_constraint.rb
+++ b/vendor/pub_grub/lib/pub_grub/version_constraint.rb
@@ -1,4 +1,4 @@
-require_relative '../pub_grub/version_range'
+require_relative 'version_range'
 
 module Gel::Vendor::PubGrub
   class VersionConstraint

--- a/vendor/pub_grub/lib/pub_grub/version_range.rb
+++ b/vendor/pub_grub/lib/pub_grub/version_range.rb
@@ -23,6 +23,10 @@ module Gel::Vendor::PubGrub
         other.empty?
       end
 
+      def hash
+        [].hash
+      end
+
       def intersects?(_)
         false
       end
@@ -133,7 +137,7 @@ module Gel::Vendor::PubGrub
       ]
     end
 
-    # Returns verisons which are included by this range.
+    # Returns versions which are included by this range.
     #
     # versions must be sorted
     def select_versions(versions)
@@ -358,6 +362,12 @@ module Gel::Vendor::PubGrub
 
     def inspect
       "#<#{self.class} #{to_s}>"
+    end
+
+    def upper_invert
+      return self.class.empty unless max
+
+      VersionRange.new(min: max, include_min: !include_max)
     end
 
     def invert

--- a/vendor/pub_grub/lib/pub_grub/version_union.rb
+++ b/vendor/pub_grub/lib/pub_grub/version_union.rb
@@ -129,6 +129,10 @@ module Gel::Vendor::PubGrub
       VersionUnion.union(new_ranges, normalize: false)
     end
 
+    def upper_invert
+      ranges.last.upper_invert
+    end
+
     def invert
       ranges.map(&:invert).inject(:intersect)
     end


### PR DESCRIPTION
Full diff: https://github.com/jhawthorn/pub_grub/compare/d3afd320bd37104f82dfbb53aefb594824f9ddf2..e5c69d251b3d55791b83d131ddd2b587a282778a

pub_grub's VersionSolver previously changed from looking at package_depth to using {matching,higher}_versions in next_package_to_try.

This commit upgrates the vendored pub_grub to include this commit, and additionally updates Gel's Solver to use the new prioritization as well (while also keeping Gel's custom priority).

(this isn't pub_grub@latest, but I figured a smaller bump first would be easier to review)